### PR TITLE
Speed optimizations for adaptive sharpen

### DIFF
--- a/ReShade/JPulowski.cfg
+++ b/ReShade/JPulowski.cfg
@@ -48,7 +48,7 @@
 #define USE_ADAPTIVESHARPEN 0 //[AdaptiveSharpen] //-Adaptive sharpen by bacondither (2015-11-17). For more information: http://forum.doom9.org/showthread.php?t=172131
 
 //>Adaptive Sharpen Settings<\\
-#define curve_height 1.0 //[0.3:1.5] //-Main sharpening strength.
+#define curve_height 1.0 //[0.3:2.0] //-Main sharpening strength.
 #define AdaptiveSharpen_ToggleKey RFX_ToggleKey //[undef] //-
 
 //>Advanced Adaptive Sharpen Settings<\\
@@ -61,4 +61,5 @@
 #define L_compr_low 0.167 //[undef] //-Max compression ratio, light overshoot (1/0.167=6x)
 #define L_compr_high 0.334 //[undef] //-pixel surrounded by edges (1/0.334=3x)
 #define max_scale_lim 0.1 //[undef] //-Abs change before max compression (0.1 = +-10%).
+#define fast_ops 1 //[0|1] //-Faster code path, small difference in quality.
 

--- a/ReShade/JPulowski.undef
+++ b/ReShade/JPulowski.undef
@@ -22,3 +22,4 @@
 #undef L_compr_low
 #undef L_compr_high
 #undef max_scale_lim
+#undef fast_ops

--- a/ReShade/JPulowski/AdaptiveSharpen.fx
+++ b/ReShade/JPulowski/AdaptiveSharpen.fx
@@ -28,9 +28,10 @@
 /* Modified for ReShade by JPulowski
    
    Changelog:
-   1.0 - Initial release
-   1.1 - Updated to version 2015-11-05
-   1.2 - Updated to version 2015-11-17, fixed tanh overflow causing black pixels
+   1.0  - Initial release
+   1.1  - Updated to version 2015-11-05
+   1.2  - Updated to version 2015-11-17, fixed tanh overflow causing black pixels
+   1.2a - Speed optimizations
    
 */   
 
@@ -41,30 +42,24 @@
 namespace JPulowski
 {
 
-texture edgeTex { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = RGBA16F; };
-sampler edgeSampler { Texture = edgeTex; };	
-
-// Edge channel offset, must be the same in both passes
-#define w_offset  2.0
+texture Pass0Tex { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = RG16F; };
+sampler Pass0_Sampler { Texture = Pass0Tex; };
 
 // Get destination pixel values
-#define get1(x, y) ( saturate(tex2D(RFX_backbufferColor, texcoord + (RFX_PixelSize * float2(x, y))).rgb) )
+#define get1(x, y)     ( saturate(tex2D(RFX_backbufferColor, texcoord + (RFX_PixelSize * float2(x, y))).rgb) )
+#define get2(x,y)      ( tex2D(Pass0_Sampler, texcoord + (RFX_PixelSize * float2(x, y))).xy )
 
 // Compute diff
-#define b_diff(z) ( abs(blur-c[z]) )
+#define b_diff(z)      ( abs(blur-c[z]) )
 
 // Saturation loss reduction
-#define minim_satloss  ( (c[0].rgb*(CtL(c[0].rgb + sharpdiff)/c0_Y) + (c[0].rgb + sharpdiff))/2 )
+#define minim_satloss  ( (satorig*(CtL(satorig + sharpdiff)/d[0].y) + (satorig + sharpdiff))/2 )
 
 // Soft if, fast
-#define soft_if(a,b,c) ( saturate((3*((a.w + b.w + c.w - 3*w_offset)/maxedge))-0.85) )
+#define soft_if(a,b,c) ( saturate((a + b + c)/(saturate(maxedge)+ 0.0067) - 0.85) )
 
 // Soft limit
 #define soft_lim(v,s)  ( ((exp(2*min(abs(v), s*16)/s) - 1)/(exp(2*min(abs(v), s*16)/s) + 1))*s )
-
-// Get destination pixel values
-#define get2(x,y)      ( tex2D(edgeSampler, texcoord + (RFX_PixelSize * float2(x, y))) )
-#define sat(input)     ( float4(saturate((input).xyz), (input).w) )
 
 // Maximum of four values
 #define max4(a,b,c,d)  ( max(max(a,b), max(c,d)) )
@@ -77,7 +72,7 @@ sampler edgeSampler { Texture = edgeTex; };
                              + abs(luma[g]-luma[c]) + abs(luma[g]-luma[d])			 \
                              + 0.5*(abs(luma[g]-luma[e]) + abs(luma[g]-luma[f])) )
 
-void AdaptiveSharpenP0(float4 vpos : SV_Position, float2 texcoord : TEXCOORD, out float4 edgeR : SV_Target0) {
+void AdaptiveSharpenP0(float4 vpos : SV_Position, float2 texcoord : TEXCOORD, out float2 P0_OUT : SV_Target0) {
 
 	// Get points and saturate out of range values (BTB & WTW)
 	// [                c22               ]
@@ -93,12 +88,15 @@ void AdaptiveSharpenP0(float4 vpos : SV_Position, float2 texcoord : TEXCOORD, ou
 	                 get1(-1, 2), get1( 3, 0), get1( 2, 1), get1( 2,-1), get1(-3, 0),
 	                 get1(-2, 1), get1(-2,-1), get1( 0,-3), get1( 1,-2), get1(-1,-2) };
 
+	// RGB to luma
+	float luma = CtL(c[0]);
+
 	// Blur, gauss 3x3
 	float3 blur   = (2*(c[2]+c[4]+c[5]+c[7]) + (c[1]+c[3]+c[6]+c[8]) + 4*c[0])/16;
 	float  blur_Y = (blur.r/3 + blur.g/3 + blur.b/3);
 
 	// Contrast compression, center = 0.5
-	float c_comp = min((0.8+2.7*pow(2, (-7.4*blur_Y))), 3.0);
+	float c_comp = saturate(0.266666681f + 0.9*pow(2, (-7.4*blur_Y)));
 
 	// Edge detection
 	// Matrix weights
@@ -111,37 +109,33 @@ void AdaptiveSharpenP0(float4 vpos : SV_Position, float2 texcoord : TEXCOORD, ou
 	                   + b_diff(4) + b_diff(5) + b_diff(6) + b_diff(7) + b_diff(8)
 	                   + 0.25*(b_diff(9) + b_diff(10) + b_diff(11) + b_diff(12)) );
 
-	edge = min(((edge*c_comp)/3 + w_offset), 32 + w_offset);
+	edge = edge*c_comp;
 
-	edgeR = float4( (tex2D(RFX_backbufferColor, texcoord).rgb), edge );
+	P0_OUT = float2( edge, luma );
 }
 
-float4 AdaptiveSharpenP1(float4 vpos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target {
+float3 AdaptiveSharpenP1(float4 vpos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target {
 
-	float4 orig = tex2D(edgeSampler, texcoord);
+	float3 orig    = tex2D(RFX_backbufferColor, texcoord).rgb;
+	float3 satorig = saturate(orig);
 
-	// Displays a green screen if the edge data is not inside a valid range in the .w channel
-	if (orig.w > (w_offset+33) || orig.w < (w_offset-0.5)  ) { return float4(0, 1, 0, 1.0); }
-
-	// Get points, saturate color data in c[0]
-	// [                c22               ]
-	// [           c24, c9,  c23          ]
-	// [      c21, c1,  c2,  c3, c18      ]
-	// [ c19, c10, c4,  c0,  c5, c11, c16 ]
-	// [      c20, c6,  c7,  c8, c17      ]
-	// [           c15, c12, c14          ]
-	// [                c13               ]
-	float4 c[25] = {  sat( orig), get2(-1,-1), get2( 0,-1), get2( 1,-1), get2(-1, 0),
+	// Get points
+	// [                d22               ]
+	// [           d24, d9,  d23          ]
+	// [      d21, d1,  d2,  d3, d18      ]
+	// [ d19, d10, d4,  d0,  d5, d11, d16 ]
+	// [      d20, d6,  d7,  d8, d17      ]
+	// [           d15, d12, d14          ]
+	// [                d13               ]
+	float2 d[25] = { get2( 0, 0), get2(-1,-1), get2( 0,-1), get2( 1,-1), get2(-1, 0),
 	                 get2( 1, 0), get2(-1, 1), get2( 0, 1), get2( 1, 1), get2( 0,-2),
 	                 get2(-2, 0), get2( 2, 0), get2( 0, 2), get2( 0, 3), get2( 1, 2),
 	                 get2(-1, 2), get2( 3, 0), get2( 2, 1), get2( 2,-1), get2(-3, 0),
 	                 get2(-2, 1), get2(-2,-1), get2( 0,-3), get2( 1,-2), get2(-1,-2) };
 
 	// Allow for higher overshoot if the current edge pixel is surrounded by similar edge pixels
-	float maxedge = max4( max4(c[1].w,c[2].w,c[3].w,c[4].w), max4(c[5].w,c[6].w,c[7].w,c[8].w),
-	                      max4(c[9].w,c[10].w,c[11].w,c[12].w), c[0].w );
-
-	maxedge  = saturate(maxedge - w_offset)*3 + 0.02;
+	float maxedge = (max4( max4(d[1].x,d[2].x,d[3].x,d[4].x), max4(d[5].x,d[6].x,d[7].x,d[8].x),
+	                       max4(d[9].x,d[10].x,d[11].x,d[12].x), d[0].x ));
 
 	// [          x          ]
 	// [       z, x, w       ]
@@ -150,21 +144,24 @@ float4 AdaptiveSharpenP1(float4 vpos : SV_Position, float2 texcoord : TEXCOORD) 
 	// [    w, w, x, z, z    ]
 	// [       w, x, z       ]
 	// [          x          ]
-	float var = soft_if(c[2],c[9],c[22]) *soft_if(c[7],c[12],c[13])  // x dir
-	          + soft_if(c[4],c[10],c[19])*soft_if(c[5],c[11],c[16])  // y dir
-	          + soft_if(c[1],c[24],c[21])*soft_if(c[8],c[14],c[17])  // z dir
-	          + soft_if(c[3],c[23],c[18])*soft_if(c[6],c[20],c[15]); // w dir
+	float var = soft_if(d[2].x,d[9].x,d[22].x) *soft_if(d[7].x,d[12].x,d[13].x)  // x dir
+	          + soft_if(d[4].x,d[10].x,d[19].x)*soft_if(d[5].x,d[11].x,d[16].x)  // y dir
+	          + soft_if(d[1].x,d[24].x,d[21].x)*soft_if(d[8].x,d[14].x,d[17].x)  // z dir
+	          + soft_if(d[3].x,d[23].x,d[18].x)*soft_if(d[6].x,d[20].x,d[15].x); // w dir
 
-	float s[2] = { lerp( L_compr_low, L_compr_high, smoothstep(2, 3.1, var) ),
-	               lerp( D_compr_low, D_compr_high, smoothstep(2, 3.1, var) ) };
+	#if fast_ops == 1
+		float s[2] = { lerp( L_compr_low, L_compr_high, saturate(var-2) ),
+		               lerp( D_compr_low, D_compr_high, saturate(var-2) ) };
+	#else
+		float s[2] = { lerp( L_compr_low, L_compr_high, smoothstep(2, 3.1, var) ),
+		               lerp( D_compr_low, D_compr_high, smoothstep(2, 3.1, var) ) };
+	#endif
 
-	// RGB to luma
-	float c0_Y = CtL(c[0]);
-
-	float luma[25] = { c0_Y, CtL(c[1]), CtL(c[2]), CtL(c[3]), CtL(c[4]), CtL(c[5]), CtL(c[6]),
-	                   CtL(c[7]),  CtL(c[8]),  CtL(c[9]),  CtL(c[10]), CtL(c[11]), CtL(c[12]),
-	                   CtL(c[13]), CtL(c[14]), CtL(c[15]), CtL(c[16]), CtL(c[17]), CtL(c[18]),
-	                   CtL(c[19]), CtL(c[20]), CtL(c[21]), CtL(c[22]), CtL(c[23]), CtL(c[24]) };
+	float luma[25] = { d[0].y,  d[1].y,  d[2].y,  d[3].y,  d[4].y,  
+	                   d[5].y,  d[6].y,  d[7].y,  d[8].y,  d[9].y,
+	                   d[10].y, d[11].y, d[12].y, d[13].y, d[14].y,
+	                   d[15].y, d[16].y, d[17].y, d[18].y, d[19].y,
+	                   d[20].y, d[21].y, d[22].y, d[23].y, d[24].y };
 
 	// Pixel weights for the laplace kernel
 	float mdiff_c0  = 0.02 + 3*( abs(luma[0]-luma[2]) + abs(luma[0]-luma[4])
@@ -182,42 +179,48 @@ float4 AdaptiveSharpenP1(float4 vpos : SV_Position, float2 texcoord : TEXCOORD) 
 	                       ( min((mdiff_c0/mdiff(17, 5,  18, 16, 3,  8,  11)), 2) ),    // c11
 	                       ( min((mdiff_c0/mdiff(13, 15, 7,  14, 6,  8,  12)), 2) ) };  // c12
 
-	weights[4]   = (max(max((weights[8]  + weights[9])/4,  weights[4]), 0.25) + weights[4])/2;
-	weights[5]   = (max(max((weights[8]  + weights[10])/4, weights[5]), 0.25) + weights[5])/2;
-	weights[6]   = (max(max((weights[9]  + weights[11])/4, weights[6]), 0.25) + weights[6])/2;
-	weights[7]   = (max(max((weights[10] + weights[11])/4, weights[7]), 0.25) + weights[7])/2;
+	weights[4] = (max(max((weights[8]  + weights[9])/4,  weights[4]), 0.25) + weights[4])/2;
+	weights[5] = (max(max((weights[8]  + weights[10])/4, weights[5]), 0.25) + weights[5])/2;
+	weights[6] = (max(max((weights[9]  + weights[11])/4, weights[6]), 0.25) + weights[6])/2;
+	weights[7] = (max(max((weights[10] + weights[11])/4, weights[7]), 0.25) + weights[7])/2;
 
 	// Calculate the negative part of the laplace kernel and the low threshold weight
 	float lowthsum    = 0;
 	float weightsum   = 0;
 	float neg_laplace = 0;
 
-	int order[12] = { 2, 4, 5, 7, 1, 3, 6, 8, 9, 10, 11, 12 };
+	static const int order[12] = { 2, 4, 5, 7, 1, 3, 6, 8, 9, 10, 11, 12 };
 
 	[unroll]
 	for (int pix = 0; pix < 12; ++pix)
 	{
-		float x       = saturate((c[order[pix]].w - w_offset - 0.01)/0.12);
-		float lowth   = x*x*(2.99 - 2*x) + 0.01;
+		#if fast_ops == 1
+			float lowth = clamp(((10*d[order[pix]].x)-0.15), 0.01, 1);
+		#else
+			float x = saturate((d[order[pix]].x - 0.01)/0.11);
+			float lowth = x*x*(2.99 - 2*x) + 0.01;
+		#endif
 
-		neg_laplace  += pow(luma[order[pix]], 2.0)*(weights[pix]*lowth);
-		weightsum    += weights[pix]*lowth;
-		lowthsum     += lowth;
+		neg_laplace += (luma[order[pix]]*luma[order[pix]])*(weights[pix]*lowth);
+		weightsum   += weights[pix]*lowth;
+		lowthsum    += lowth;
 	}
 
-	neg_laplace = pow((neg_laplace/weightsum), (1.0/2.0));
-
 	// Compute sharpening magnitude function
-	float c_edge = abs(c[0].w - w_offset);
-
-	float sharpen_val = (lowthsum/12)*(curve_height/(curveslope*pow(c_edge, 3.5) + 0.5));
+	float sharpen_val = (lowthsum/12)*(curve_height/(curveslope*pow(abs(d[0].x), 3.5) + 0.5));
 
 	// Calculate sharpening diff and scale
-	float sharpdiff = (c0_Y - neg_laplace)*(sharpen_val*0.8 + 0.01);
+	float sharpdiff = (d[0].y - sqrt(neg_laplace/weightsum))*(sharpen_val*0.8 + 0.01);
 
+	#if fast_ops == 1
+		static const int numloop = 2;
+	#else
+		static const int numloop = 3;
+	#endif
+	
 	// Calculate local near min & max, partial cocktail sort (No branching!)
 	[unroll]
-	for (int i = 0; i < 3; ++i)
+	for (int i = 0; i < numloop; ++i)
 	{
 		for (int i1 = 1+i; i1 < 25-i; ++i1)
 		{
@@ -234,12 +237,17 @@ float4 AdaptiveSharpenP1(float4 vpos : SV_Position, float2 texcoord : TEXCOORD) 
 		}
 	}
 
-	float nmax = max(((luma[22] + luma[23]*2 + luma[24])/4), c0_Y);
-	float nmin = min(((luma[0]  + luma[1]*2  + luma[2])/4),  c0_Y);
+	#if fast_ops == 1
+		float nmax = max((luma[23] + luma[24])/2, d[0].y);
+		float nmin = min((luma[0]  + luma[1])/2,  d[0].y);
+	#else
+		float nmax = max(((luma[22] + luma[23]*2 + luma[24])/4), d[0].y);
+		float nmin = min(((luma[0]  + luma[1]*2  + luma[2])/4),  d[0].y);
+	#endif
 
 	// Calculate tanh scale factor, pos/neg
-	float nmax_scale = min(((nmax - c0_Y) + L_overshoot), max_scale_lim);
-	float nmin_scale = min(((c0_Y - nmin) + D_overshoot), max_scale_lim);
+	float nmax_scale = min(((nmax - d[0].y) + L_overshoot), max_scale_lim);
+	float nmin_scale = min(((d[0].y - nmin) + D_overshoot), max_scale_lim);
 
 	// Soft limit sharpening with tanh, lerp to control maximum compression
 	sharpdiff = lerp(  (soft_lim(max(sharpdiff, 0), nmax_scale)), max(sharpdiff, 0), s[0] )
@@ -248,16 +256,16 @@ float4 AdaptiveSharpenP1(float4 vpos : SV_Position, float2 texcoord : TEXCOORD) 
 	/*if (video_level_out == true)
 	{
 		[flatten]
-		if (sharpdiff > 0) { return float4( orig.rgb + (minim_satloss - c[0].rgb), 1.0 ); }
+		if (sharpdiff > 0) { return ( orig + (minim_satloss - satorig) ); }
 
-		else { return float4( (orig.rgb + sharpdiff), 1.0 ); }
+		else { return ( orig + sharpdiff ); }
 	}*/
 
 	// Normal path
 	[flatten]
-	if (sharpdiff > 0) { return float4( minim_satloss, 1.0 ); }
+	if (sharpdiff > 0) { return minim_satloss; }
 
-	else { return float4( (c[0].rgb + sharpdiff), 1.0 ); }
+	else { return ( satorig + sharpdiff ); }
 }
 
 technique AdaptiveSharpen_Tech <bool enabled = RFX_Start_Enabled; int toggle = AdaptiveSharpen_ToggleKey; >
@@ -265,25 +273,23 @@ technique AdaptiveSharpen_Tech <bool enabled = RFX_Start_Enabled; int toggle = A
 	pass AdaptiveSharpenPass1
 	{
 		VertexShader = RFX_VS_PostProcess;
-		PixelShader = AdaptiveSharpenP0;
-		RenderTarget = edgeTex;
+		PixelShader  = AdaptiveSharpenP0;
+		RenderTarget = Pass0Tex;
 	}
 	
 	pass AdaptiveSharpenPass2
 	{
 		VertexShader = RFX_VS_PostProcess;
-		PixelShader = AdaptiveSharpenP1;
+		PixelShader  = AdaptiveSharpenP1;
 	}
 }
 
-#undef w_offset
 #undef get1
+#undef get2
 #undef b_diff
 #undef minim_satloss
 #undef soft_if
 #undef soft_lim
-#undef get2
-#undef sat
 #undef max4
 #undef CtL
 #undef mdiff


### PR DESCRIPTION
The first pass now passes edge and luma data in a RG16F texture.

Added a fast code path "fast_ops" that is enabled by default and gives a
very small perceptual differance and a good speedup.

Rendering time differences (effect on - off) with a AMD7790@1080p:
1.2                   - 3.2ms
1.2a, fastops 0 - 2.5ms  ~28% speedup
1.2a, fastops 1 - 2.2ms  ~45% speedup