### PR TITLE
Updated Otis/DepthHaze effect with fog 

### DIFF
--- a/ReShade/Presets/Default/Otis.cfg
+++ b/ReShade/Presets/Default/Otis.cfg
@@ -22,10 +22,13 @@
 ////-------------//
 ///**DEPTHHAZE**///
 //-------------////
-#define USE_DEPTHHAZE 0 //[DepthHaze] //-This simple effect slightly blurs the far away scenery based on the depth buffer. It's a small, detuned depth of field with only a far plane. The effect is not a lens effect but an effect mimicing the blurryness/hazyness of far away objects caused by haze and the lack of the human eye to see far away detail. Modern render engines often render far away scenery with a crisp pixel detail causing it to look 'off'. This effect tries to mitigate that. If your game uses a logarithmic depth buffer, you have to switch on RFX_LogDepth in common.cfg.
+#define USE_DEPTHHAZE 0 //[DepthHaze] //-This simple effect slightly blurs and fogs the far away scenery based on the depth buffer. It's a small, detuned depth of field with only a far plane combined with optionally fog injection. The effect is not a lens effect but an effect mimicing the blurryness/hazyness of far away objects caused by haze and the lack of the human eye to see far away detail. Modern render engines often render far away scenery with a crisp pixel detail causing it to look 'off'. This effect tries to mitigate that. Requires the game to have an active depth buffer.
 
 //>DEPTH HAZE Settings<\\
 #define DEH_EffectStrength 0.6 //[0.0:1.0] //-The strength of the effect. Range from 0.0, which means no effect, till 1.0 which means pixels are 100% blurred based on depth.
+#define DEH_FogColor float3(1.0, 0.8, 0.2) //[0.0:1.0] //-Color of the fog (r, g, b). 
+#define DEH_FogStart 0.3 //[0.0:1.0] //-Start of the fog. 0.0 is at the camera, 1.0 is at the horizon, 0.5 is halfway towards the horizon. Before this point no fog will appear
+#define DEH_FogFactor 0.6 //[0.0:1.0] //-The amount of fog added to the scene. 0.0 is no fog, 1.0 is the strongest fog possible
 #define DEH_ToggleKey RESHADE_TOGGLE_KEY //[undef] //-Key to toggle the effect on or off
 
 

--- a/ReShade/Shaders/Otis.undef
+++ b/ReShade/Shaders/Otis.undef
@@ -4,6 +4,9 @@
 #undef GOR_ToggleKey
 #undef USE_DEPTHHAZE
 #undef DEH_EffectStrength
+#undef DEH_FogColor
+#undef DEH_FogStart
+#undef DEH_FogFactor
 #undef DEH_ToggleKey
 #undef USE_EMPHASIZE
 #undef EMZ_ManualFocusDepth

--- a/ReShade/Shaders/Otis/DepthHaze.fx
+++ b/ReShade/Shaders/Otis/DepthHaze.fx
@@ -68,6 +68,14 @@ void PS_Otis_DEH_BlockBlurVertical(in float4 pos : SV_Position, in float2 texcoo
 
 void PS_Otis_DEH_BlendBlurWithNormalBuffer(float4 vpos: SV_Position, float2 texcoord: TEXCOORD, out float4 fragment: SV_Target0)
 {
+	float depth = tex2D(ReShade::LinearizedDepth,texcoord).r;
+	float4 blendedFragment = lerp(tex2D(ReShade::BackBuffer, texcoord), tex2D(Otis_SamplerFragmentBuffer2, texcoord),
+								  clamp(depth  * DEH_EffectStrength, 0.0, 1.0)); 
+	float yFactor = clamp(texcoord.y > 0.5 ? 1-((texcoord.y-0.5)*2.0) : texcoord.y * 2.0, 0, 1);
+	fragment = lerp(blendedFragment, float4(DEH_FogColor, blendedFragment.r), 
+					clamp((depth-DEH_FogStart) * yFactor * DEH_FogFactor, 0.0, 1.0));
+
+
 	fragment = lerp(tex2D(ReShade::BackBuffer, texcoord), tex2D(Otis_SamplerFragmentBuffer2, texcoord), 
 					clamp( tex2D(ReShade::LinearizedDepth,texcoord).r * DEH_EffectStrength, 0, 1)); 
 }

--- a/ReShade/Shaders/Otis/DepthHaze.fx
+++ b/ReShade/Shaders/Otis/DepthHaze.fx
@@ -74,10 +74,6 @@ void PS_Otis_DEH_BlendBlurWithNormalBuffer(float4 vpos: SV_Position, float2 texc
 	float yFactor = clamp(texcoord.y > 0.5 ? 1-((texcoord.y-0.5)*2.0) : texcoord.y * 2.0, 0, 1);
 	fragment = lerp(blendedFragment, float4(DEH_FogColor, blendedFragment.r), 
 					clamp((depth-DEH_FogStart) * yFactor * DEH_FogFactor, 0.0, 1.0));
-
-
-	fragment = lerp(tex2D(ReShade::BackBuffer, texcoord), tex2D(Otis_SamplerFragmentBuffer2, texcoord), 
-					clamp( tex2D(ReShade::LinearizedDepth,texcoord).r * DEH_EffectStrength, 0, 1)); 
 }
 
 technique Otis_DEH_Tech <bool enabled = false; int toggle = DEH_ToggleKey; >


### PR DESCRIPTION
I added a fog feature to the DepthHaze shader so it's now possible to add depth based fog (around the center of the screen). So it's not adding fog simply based on depth, it is more pronounced around the center line of the screen (to avoid fogged skies which look awful ;)) See: http://imgur.com/et18C7B&IwKr2kG&U1R1Kwh&sg5c5JA for examples. 

I hope I have done everything correctly. I can't test it as I don't have the v2.0 reshade dll. If I have to adjust a setting or something, please let me know :) This also addresses: http://reshade.me/forum/releases/1381-1-1?start=60#12765 