### PR TITLE
Added Adaptive Fog effect

### DIFF
--- a/ReShade/Presets/Default/Pipeline.cfg
+++ b/ReShade/Presets/Default/Pipeline.cfg
@@ -51,5 +51,6 @@
 #include EFFECT(CeeJay, DisplayDepth)
 #include EFFECT(Otis, Emphasize)
 #include EFFECT(Otis, GoldenRatio)
+#include EFFECT(Otis, AdaptiveFog)
 #include EFFECT(Otis, MouseOverlay)
 #include EFFECT(Ganossa, Histogram)

--- a/ReShade/Presets/Default/Shaders_by_Otis.cfg
+++ b/ReShade/Presets/Default/Shaders_by_Otis.cfg
@@ -58,7 +58,8 @@
 #define AFG_MouseDrivenFogColorSelect 0 //[0,1] //-If 1, you can use the mouse overlay (enabled with the MOL_ToggleKey defined in the MouseOverlay effect) to select the fog color from the scene. If 0, it will use AFG_Color as fog color.
 #define AFG_Color float3(0.9,0.9,0.9) //[0.0:1.0] //-Color of the fog (r, g, b). Ignored if AFG_MouseDrivenFogColorSelect is 1.
 #define AFG_MaxFogFactor 0.9 //[0.0:1.0] //-The maximum fog factor. 1.0 makes distant objects completely fogged out, a lower factor will shimmer them through the fog.
-#define AFG_FogCurve 2.0 // [0.1:175.0] //-The curve how quickly distant objects get fogged. A low value will make the fog appear just slightly. A high value will make the fog kick in rather quickly. The max value in the rage makes it very hard in general to view any objects outside fog.
+#define AFG_FogCurve 2.0 //[0.1:175.0] //-The curve how quickly distant objects get fogged. A low value will make the fog appear just slightly. A high value will make the fog kick in rather quickly. The max value in the rage makes it very hard in general to view any objects outside fog.
+#define AFG_FogStart 0.0 //[0.0:1.0] //-The start of the fog. 0.0 is at the camera position, 1.0 is horizon. 
 #define AFG_ToggleKey RESHADE_TOGGLE_KEY //[undef] //-Key to toggle the effect on or off
 
 //>ADAPTIVE FOG Bloom Settings<\\

--- a/ReShade/Presets/Default/Shaders_by_Otis.cfg
+++ b/ReShade/Presets/Default/Shaders_by_Otis.cfg
@@ -48,3 +48,20 @@
 #define MOL_CursorSize 3 //[1:100] //-The x and y size of the element displayed at the location of the mouse coordinates, in pixels 
 #define MOL_CursorColor float3(1.0,0.0,0.0) //[0.0:1.0] //-Specifies the color of the element displayed at the location of the mouse coordinates. (r, g, b)
 
+
+////---------------//
+///**ADAPTIVEFOG**///
+//---------------////
+#define USE_ADAPTIVEFOG 0 //[AdaptiveFog] //-Bloom driven depth-based fog. It uses an overly bloomed version of the frame buffer combined with the depth buffer to create a fog volume in the scene. The bloom is used to fake light diffusion around lights. This effect is toggled off by default, you need to define a toggle key to enable it.
+
+//>ADAPTIVE FOG General Settings<\\
+#define AFG_MouseDrivenFogColorSelect 0 //[0,1] //-If 1, you can use the mouse overlay (enabled with the MOL_ToggleKey defined in the MouseOverlay effect) to select the fog color from the scene. If 0, it will use AFG_Color as fog color.
+#define AFG_Color float3(0.9,0.9,0.9) //[0.0:1.0] //-Color of the fog (r, g, b). Ignored if AFG_MouseDrivenFogColorSelect is 1.
+#define AFG_MaxFogFactor 0.9 //[0.0:1.0] //-The maximum fog factor. 1.0 makes distant objects completely fogged out, a lower factor will shimmer them through the fog.
+#define AFG_FogCurve 2.0 // [0.1:175.0] //-The curve how quickly distant objects get fogged. A low value will make the fog appear just slightly. A high value will make the fog kick in rather quickly. The max value in the rage makes it very hard in general to view any objects outside fog.
+#define AFG_ToggleKey RESHADE_TOGGLE_KEY //[undef] //-Key to toggle the effect on or off
+
+//>ADAPTIVE FOG Bloom Settings<\\
+#define AFG_BloomThreshold 2.25 //[0.00:50.00] //-Threshold for what is a bright light (that causes bloom) and what isn't.
+#define AFG_BloomPower 10.000 //[0.000:100.000] //-Strength of the bloom
+#define AFG_BloomWidth 0.3 //[0.0000:1.0000] //-Width of the bloom

--- a/ReShade/Shaders/Otis.undef
+++ b/ReShade/Shaders/Otis.undef
@@ -29,3 +29,4 @@
 #undef AFG_BloomThreshold
 #undef AFG_BloomPower
 #undef AFG_BloomWidth
+#undef AFG_FogStart

--- a/ReShade/Shaders/Otis.undef
+++ b/ReShade/Shaders/Otis.undef
@@ -20,3 +20,12 @@
 #undef MOL_ToggleKey
 #undef MOL_CursorSize
 #undef MOL_CursorColor
+#undef USE_ADAPTIVEFOG
+#undef AFG_Color 
+#undef AFG_MaxFogFactor
+#undef AFG_FogCurve
+#undef AFG_ToggleKey
+#undef AFG_MouseDrivenFogColorSelect
+#undef AFG_BloomThreshold
+#undef AFG_BloomPower
+#undef AFG_BloomWidth

--- a/ReShade/Shaders/Otis/AdaptiveFog.fx
+++ b/ReShade/Shaders/Otis/AdaptiveFog.fx
@@ -1,0 +1,87 @@
+///////////////////////////////////////////////////////////////////
+// Simple depth-based AFG
+///////////////////////////////////////////////////////////////////
+
+#include EFFECT_CONFIG(Otis)
+#include "Common.fx"
+
+#if USE_ADAPTIVEFOG
+
+#pragma message "Adaptive Fog by Otis, with bloom code from CeeJay.\n"
+
+namespace Otis
+{
+
+texture   Otis_BloomTarget 	{ Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = Otis_RENDERMODE;};	
+sampler2D Otis_BloomSampler { Texture = Otis_BloomTarget; };
+
+// pixel shader which performs bloom, by CeeJay. 
+void PS_Otis_AFG_PerformBloom(float4 position : SV_Position, float2 texcoord : TEXCOORD0, out float4 fragment: SV_Target0)
+{
+	float4 color = tex2D(ReShade::BackBuffer, texcoord);
+	float3 BlurColor2 = 0;
+	float3 Blurtemp = 0;
+	float MaxDistance = 8*AFG_BloomWidth;
+	float CurDistance = 0;
+	float Samplecount = 25.0;
+	float2 blurtempvalue = texcoord * ReShade::PixelSize * AFG_BloomWidth;
+	float2 BloomSample = float2(2.5,-2.5);
+	float2 BloomSampleValue;
+	
+	for(BloomSample.x = (2.5); BloomSample.x > -2.0; BloomSample.x = BloomSample.x - 1.0)
+	{
+		BloomSampleValue.x = BloomSample.x * blurtempvalue.x;
+		float2 distancetemp = BloomSample.x * BloomSample.x * AFG_BloomWidth;
+		
+		for(BloomSample.y = (- 2.5); BloomSample.y < 2.0; BloomSample.y = BloomSample.y + 1.0)
+		{
+			distancetemp.y = BloomSample.y * BloomSample.y;
+			CurDistance = (distancetemp.y * AFG_BloomWidth) + distancetemp.x;
+			BloomSampleValue.y = BloomSample.y * blurtempvalue.y;
+			Blurtemp.rgb = tex2D(ReShade::BackBuffer, float2(texcoord + BloomSampleValue)).rgb;
+			BlurColor2.rgb += lerp(Blurtemp.rgb,color.rgb, sqrt(CurDistance / MaxDistance));
+		}
+	}
+	BlurColor2.rgb = (BlurColor2.rgb / (Samplecount - (AFG_BloomPower - AFG_BloomThreshold*5)));
+	float Bloomamount = (dot(color.rgb,float3(0.299f, 0.587f, 0.114f)));
+	float3 BlurColor = BlurColor2.rgb * (AFG_BloomPower + 4.0);
+	color.rgb = lerp(color.rgb,BlurColor.rgb, Bloomamount);	
+	fragment = saturate(color);
+}
+
+
+void PS_Otis_AFG_BlendFogWithNormalBuffer(float4 vpos: SV_Position, float2 texcoord: TEXCOORD, out float4 fragment: SV_Target0)
+{
+	float depth = tex2D(ReShade::LinearizedDepth, texcoord).r;
+	float4 bloomedFragment = tex2D(Otis_BloomSampler, texcoord);
+	float4 colorFragment = tex2D(ReShade::BackBuffer, texcoord);
+	float4 fogColor = float4(AFG_Color, 1.0);
+#if AFG_MouseDrivenFogColorSelect
+	fogColor = tex2D(ReShade::BackBuffer, ReShade::MouseCoords * ReShade::PixelSize);
+#endif
+	float fogFactor = clamp(depth * AFG_FogCurve, 0.0, AFG_MaxFogFactor); 
+	float4 bloomedBlendedWithFogFragment = lerp(bloomedFragment, fogColor, fogFactor);
+	fragment = lerp(colorFragment, bloomedBlendedWithFogFragment, fogFactor);
+}
+
+technique Otis_AFG_Tech <bool enabled = false; int toggle = AFG_ToggleKey; >
+{
+	pass Otis_AFG_PassAverage0
+	{
+		VertexShader = ReShade::VS_PostProcess;
+		PixelShader = PS_Otis_AFG_PerformBloom;
+		RenderTarget = Otis_BloomTarget;
+	}
+	
+	pass Otis_AFG_PassBlend
+	{
+		VertexShader = ReShade::VS_PostProcess;
+		PixelShader = PS_Otis_AFG_BlendFogWithNormalBuffer;
+	}
+}
+
+}
+
+#endif
+
+#include EFFECT_CONFIG_UNDEF(Otis)


### PR DESCRIPTION
Adaptive fog is a simple depth-based fog effect which combines depth-based fogging with a bloomed version of the framebuffer to fake light diffusion. It's controllable through mouse coordinates to pick the
fog color from the scene. Highly configurable so you can add whatever fog type you like.

Examples:
extreme fog parameters: https://farm2.staticflickr.com/1523/25856171573_45dbb6f64a_o.jpg
Fog with more normal parameters: http://abload.de/img/acs2016-04-1613-13-5883lv2.png
Fog off, same scene: http://abload.de/img/acs2016-04-1613-14-02mpcnn.png
