### PR TITLE
Changed default pattern for LumaSharpen

### DIFF
--- a/Shaders/LumaSharpen.fx
+++ b/Shaders/LumaSharpen.fx
@@ -21,7 +21,7 @@ uniform int pattern <
 	ui_type = "combo";
 	ui_items = "Fast\0Normal\0Wider\0Pyramid shaped\0";
 	ui_tooltip = "Choose a sample pattern";
-> = 2;
+> = 1;
 uniform float offset_bias <
 	ui_type = "drag";
 	ui_min = 0.0; ui_max = 6.0;


### PR DESCRIPTION
The default pattern should be "normal" not "wider". According to new
scheme pattern should be set to 1, not 2 which was the case in the
previous scheme.