### PR TITLE
Enhances Emphasize shader with a 3D component

### DIFF
--- a/Shaders/Emphasize.fx
+++ b/Shaders/Emphasize.fx
@@ -1,27 +1,48 @@
-///////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////
 // This effect works like a simple DoF for desaturating what otherwise would have been blurred.
 //
 // It works by determining whether a pixel is outside the emphasize zone using the depth buffer
 // if so, the pixel is desaturated and blended with the color specified in the cfg file. 
 ///////////////////////////////////////////////////////////////////
-// By Otis / Infuse Project
+// Main shader by Otis / Infuse Project
+// 3D emphasis code by SirCobra. 
 ///////////////////////////////////////////////////////////////////
-
-uniform float ManualFocusDepth <
+uniform float FocusDepth <
 	ui_type = "drag";
-	ui_min = 0.0; ui_max = 1.0;
+	ui_min = 0.000; ui_max = 1.000;
+	ui_step = 0.001;
 	ui_tooltip = "Manual focus depth of the point which has the focus. Range from 0.0, which means camera is the focus plane, till 1.0 which means the horizon is focus plane.";
 > = 0.026;
 uniform float FocusRangeDepth <
 	ui_type = "drag";
-	ui_min = 0.0; ui_max = 1.0;
+	ui_min = 0.0; ui_max = 1.000;
+	ui_step = 0.001;
 	ui_tooltip = "The depth of the range around the manual focus depth which should be emphasized. Outside this range, de-emphasizing takes place";
-> = 0.01;
+> = 0.001;
 uniform float FocusEdgeDepth <
 	ui_type = "drag";
-	ui_min = 0.0; ui_max = 1.0;
-	ui_tooltip = "The depth of the edge of the focus range. Range from 0.00, which means no depth, so at the edge of the focus range, the effect kicks in at full force, till 1.00, which means the effect is smoothly applied over the range focusRangeEdge-horizon.";
-> = 0.05;
+	ui_min = 0.000; ui_max = 1.000;
+	ui_tooltip = "The depth of the edge of the focus range. Range from 0.00, which means no depth, so at the edge of the focus range, the effect kicks in at full force,\ntill 1.00, which means the effect is smoothly applied over the range focusRangeEdge-horizon.";
+	ui_step = 0.001;
+> = 0.050;
+uniform bool Spherical <
+	ui_tooltip = "Enables Emphasize in a sphere around the focus-point instead of a 2D plane";
+> = false;
+uniform int Sphere_FieldOfView <
+	ui_type = "drag";
+	ui_min = 1; ui_max = 180;
+	ui_tooltip = "Specifies the estimated Field of View you are currently playing with. Range from 1, which means 1 Degree, till 180 which means 180 Degree (half the scene).\nNormal games tend to use values between 60 and 90.";
+> = 75;
+uniform float Sphere_FocusHorizontal <
+	ui_type = "drag";
+	ui_min = 0; ui_max = 1;
+	ui_tooltip = "Specifies the location of the focuspoint on the horizontal axis. Range from 0, which means left screen border, till 1 which means right screen border.";
+> = 0.5;
+uniform float Sphere_FocusVertical <
+	ui_type = "drag";
+	ui_min = 0; ui_max = 1;
+	ui_tooltip = "Specifies the location of the focuspoint on the vertical axis. Range from 0, which means upper screen border, till 1 which means bottom screen border.";
+> = 0.5;
 uniform float3 BlendColor <
 	ui_type = "color";
 	ui_tooltip = "Specifies the blend color to blend with the greyscale. in (Red, Green, Blue). Use dark colors to darken further away objects";
@@ -34,23 +55,41 @@ uniform float BlendFactor <
 uniform float EffectFactor <
 	ui_type = "drag";
 	ui_min = 0.0; ui_max = 1.0;
-	ui_tooltip = "Specifies the factor the desaturation is applied. Range from 0.0, which means the effect is off (normal image), till 1.0 which means the desaturated parts are full greyscale (or color blending if that's enabled)";
+	ui_tooltip = "Specifies the factor the desaturation is applied. Range from 0.0, which means the effect is off (normal image), till 1.0 which means the desaturated parts are\nfull greyscale (or color blending if that's enabled)";
 > = 0.9;
 
 #include "Reshade.fxh"
 
-float CalculateDepthDiffCoC(float scenedepth)
+#ifndef M_PI
+	#define M_PI 3.1415927
+#endif
+
+float CalculateDepthDiffCoC(float2 texcoord : TEXCOORD)
 {
-	const float scenefocus =  ManualFocusDepth;
+	const float scenedepth = ReShade::GetLinearizedDepth(texcoord);
+	const float scenefocus =  FocusDepth;
 	const float desaturateFullRange = FocusRangeDepth+FocusEdgeDepth;
-	const float depthdiff = abs(scenedepth-scenefocus);
-	return saturate((depthdiff > desaturateFullRange) ? 1.0 : smoothstep(scenefocus, scenefocus+desaturateFullRange, scenefocus + depthdiff));
+	float depthdiff;
+	
+	if(Spherical == true)
+	{
+		texcoord.x = (texcoord.x-Sphere_FocusHorizontal)*ReShade::ScreenSize.x;
+		texcoord.y = (texcoord.y-Sphere_FocusVertical)*ReShade::ScreenSize.y;
+		const float degreePerPixel = Sphere_FieldOfView / ReShade::ScreenSize.x;
+		const float fovDifference = sqrt((texcoord.x*texcoord.x)+(texcoord.y*texcoord.y))*degreePerPixel;
+		depthdiff = sqrt((scenedepth*scenedepth)+(scenefocus*scenefocus)-(2*scenedepth*scenefocus*cos(fovDifference*(2*M_PI/360))));
+	}
+	else
+	{
+		depthdiff = abs(scenedepth-scenefocus);
+	}
+	
+	return saturate((depthdiff > desaturateFullRange) ? 1.0 : smoothstep(0, desaturateFullRange, depthdiff));
 }
 
 void PS_Otis_EMZ_Desaturate(float4 vpos : SV_Position, float2 texcoord : TEXCOORD, out float4 outFragment : SV_Target)
 {
-	const float scenedepth = ReShade::GetLinearizedDepth(texcoord);
-	const float depthDiffCoC = CalculateDepthDiffCoC(scenedepth);	
+	const float depthDiffCoC = CalculateDepthDiffCoC(texcoord.xy);	
 	const float4 colFragment = tex2D(ReShade::BackBuffer, texcoord);
 	const float greyscaleAverage = (colFragment.x + colFragment.y + colFragment.z) / 3.0;
 	float4 desColor = float4(greyscaleAverage, greyscaleAverage, greyscaleAverage, depthDiffCoC);


### PR DESCRIPTION
Enhances Emphasize shader with a 3D component so it now allows to specify a sphere instead of a 2D plane (both options are still available). Enhancement by SirCobra, who asked me to commit this change to the main repo. (his words: The zone can now be calculated on the distance of a pixel to a focus-point in it's estimated 3D environment.) 

Looks something like this:  
![acorigins_2018_07_30_10_31_42_794](https://user-images.githubusercontent.com/3628530/43387065-c36fb6e4-93e5-11e8-9535-8c0e229c692c.png)

:smiley: 