### PR TITLE
CinematicDOF: Much better bokeh highlighting, better control over highlights, larger range for manual focus

### DIFF
--- a/Shaders/CinematicDOF.fx
+++ b/Shaders/CinematicDOF.fx
@@ -32,6 +32,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // Version history:
+// 17-aug-2018:		v1.0.5: Much better highlighting, higher range for manual focus
 // 12-aug-2018:		v1.0.4: Finetuned the workaround for d3d9 to only affect reshade 3.4 or lower. 
 //							Finetuned the near highlight extrapolation a bit. Removed highlight threshold as it ruined the blur
 // 10-aug-2018:		v1.0.3: Daodan's crosshair code added.


### PR DESCRIPTION
The bokeh highlights are much better now:

- no more errors around edges where the depth buffer doesn't align with framebuffer (happens in some UE3 games I've seen)
- allows for 'busy' bokeh where you can create highlights with a slighter brigher edge than the center
- better control over highlight brightness (separated near/far plane)

Also increased manual focus range in the slider to 150 max. (was 100). 

Example: 
![rememberme 2018-08-17 16-49-55](https://user-images.githubusercontent.com/3628530/44274722-201bc700-a243-11e8-887b-9a0bef59c6f0.jpg)

![rememberme 2018-08-18 11-15-28](https://user-images.githubusercontent.com/3628530/44298041-39bd1d00-a2dc-11e8-8be5-6036287f717b.jpg)
