### PR TITLE
Updated Cinematic DOF shader

### DIFF
--- a/Shaders/CinematicDOF.fx
+++ b/Shaders/CinematicDOF.fx
@@ -242,8 +242,8 @@ namespace CinematicDOF
 	#define PI 					3.1415926535897932
 
 	texture texCDFocus			{ Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = R16F; };
-	texture texCDFocusTmp1		{ Width = BUFFER_WIDTH/2; Height = BUFFER_HEIGHT/2; Format = RG16F; };		// width reduced as it's not noticable 
-	texture texCDFocusBlurred	{ Width = BUFFER_WIDTH/2; Height = BUFFER_HEIGHT/2; Format = RG16F; };		// width reduced as it's not noticable
+	texture texCDFocusTmp1		{ Width = BUFFER_WIDTH/2; Height = BUFFER_HEIGHT/2; Format = R16F; };	// half res, single value
+	texture texCDFocusBlurred	{ Width = BUFFER_WIDTH/2; Height = BUFFER_HEIGHT/2; Format = RG16F; };	// half res, blurred CoC (r) and real CoC (g)
 	texture texCDBuffer1 		{ Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = RGBA8; };
 	texture texCDBuffer2 		{ Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = RGBA8; }; 
 	texture texCDBuffer3 		{ Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = RGBA8; }; 
@@ -656,10 +656,10 @@ namespace CinematicDOF
 	}
 
 	// Pixel shader which performs the first part of the gaussian blur on the blur disc values
-	void PS_CoCGaussian1(float4 vpos : SV_Position, float2 texcoord : TEXCOORD, out float2 fragment : SV_Target0)
+	void PS_CoCGaussian1(float4 vpos : SV_Position, float2 texcoord : TEXCOORD, out float fragment : SV_Target0)
 	{
 		// from source CoC to tmp1
-		fragment = float2(PerformSingleValueGaussianBlur(SamplerCDFocus, texcoord, float2(ReShade::PixelSize.x, 0.0), true), 0);
+		fragment = PerformSingleValueGaussianBlur(SamplerCDFocus, texcoord, float2(ReShade::PixelSize.x, 0.0), true);
 	}
 
 	// Pixel shader which performs the second part of the gaussian blur on the blur disc values

--- a/Shaders/CinematicDOF.fx
+++ b/Shaders/CinematicDOF.fx
@@ -56,9 +56,6 @@
 // [Jimenez2014]	Jorge Jimenez, Sledgehammer Games: Next generation post processing in Call of Duty Advanced Warfare, SIGGRAPH2014
 //					http://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare
 //
-// [Hammon2007]		Earl Hammon, jr, Infinity Ward: Practical Post-Processing Detph of Field, CPU Gems 3, ch. 28.
-//					http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.302.2964&rep=rep1&type=pdf
-//
 // [Nilsson2012]	Filip Nilsson: Implementing realistic depth of field in OpenGL. 
 //					http://fileadmin.cs.lth.se/cs/education/edan35/lectures/12dof.pdf
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Made several improvements to the Cinematic DOF shader:

- Much better near-plane bleed: 
![mobile_2018_09_21_14_44_29_971](https://user-images.githubusercontent.com/3628530/45896050-3fbe8600-bdd3-11e8-9f0c-6031060cf707.png)

- Corrected an issue with the post-gaussian blur bleeding near focus pixels
- Optimized things across the board
- Corrected near-plane highlight bleed. 
- Corrected comments, removed reference of info no longer used. 