### PR TITLE
Bug fixes in CinematiC DOF and Adaptive Fog

### DIFF
--- a/Shaders/AdaptiveFog.fx
+++ b/Shaders/AdaptiveFog.fx
@@ -17,8 +17,9 @@ uniform float3 FogColor <
 
 uniform float MaxFogFactor <
 	ui_type = "drag";
-	ui_min = 0.0; ui_max=1.0;
+	ui_min = 0.000; ui_max=1.000;
 	ui_tooltip = "The maximum fog factor. 1.0 makes distant objects completely fogged out, a lower factor will shimmer them through the fog.";
+	ui_step = 0.01;
 > = 0.8;
 
 uniform float FogCurve <
@@ -29,9 +30,10 @@ uniform float FogCurve <
 
 uniform float FogStart <
 	ui_type = "drag";
-	ui_min = 0.0; ui_max=1.0;
+	ui_min = 0.000; ui_max=1.000;
+	ui_step = 0.001;
 	ui_tooltip = "Start of the fog. 0.0 is at the camera, 1.0 is at the horizon, 0.5 is halfway towards the horizon. Before this point no fog will appear.";
-> = 0.05;
+> = 0.050;
 
 uniform float BloomThreshold <
 	ui_type = "drag";

--- a/Shaders/AdaptiveFog.fx
+++ b/Shaders/AdaptiveFog.fx
@@ -19,12 +19,13 @@ uniform float MaxFogFactor <
 	ui_type = "drag";
 	ui_min = 0.000; ui_max=1.000;
 	ui_tooltip = "The maximum fog factor. 1.0 makes distant objects completely fogged out, a lower factor will shimmer them through the fog.";
-	ui_step = 0.01;
+	ui_step = 0.001;
 > = 0.8;
 
 uniform float FogCurve <
 	ui_type = "drag";
-	ui_min = 0.0; ui_max=175.0;
+	ui_min = 0.00; ui_max=175.00;
+	ui_step = 0.01;
 	ui_tooltip = "The curve how quickly distant objects get fogged. A low value will make the fog appear just slightly. A high value will make the fog kick in rather quickly. The max value in the rage makes it very hard in general to view any objects outside fog.";
 > = 1.5;
 
@@ -38,12 +39,14 @@ uniform float FogStart <
 uniform float BloomThreshold <
 	ui_type = "drag";
 	ui_min = 0.00; ui_max=50.00;
+	ui_step = 0.1;
 	ui_tooltip = "Threshold for what is a bright light (that causes bloom) and what isn't.";
 > = 10.25;
 
 uniform float BloomPower <
 	ui_type = "drag";
 	ui_min = 0.000; ui_max=100.000;
+	ui_step = 0.1;
 	ui_tooltip = "Strength of the bloom";
 > = 10.0;
 
@@ -103,12 +106,8 @@ void PS_Otis_AFG_PerformBloom(float4 position : SV_Position, float2 texcoord : T
 void PS_Otis_AFG_BlendFogWithNormalBuffer(float4 vpos: SV_Position, float2 texcoord: TEXCOORD, out float4 fragment: SV_Target0)
 {
 	float depth = ReShade::GetLinearizedDepth(texcoord).r;
-	depth = (depth * (1.0+FogStart)) - FogStart;
-	float4 bloomedFragment = tex2D(Otis_BloomSampler, texcoord);
-	float4 colorFragment = tex2D(ReShade::BackBuffer, texcoord);
-	float fogFactor = clamp(depth * FogCurve, 0.0, MaxFogFactor); 
-	float4 bloomedBlendedWithFogFragment = lerp(bloomedFragment, float4(FogColor, 1.0), fogFactor);
-	fragment = lerp(colorFragment, bloomedBlendedWithFogFragment, fogFactor);
+	float fogFactor = clamp(saturate(depth - FogStart) * FogCurve, 0.0, MaxFogFactor); 
+	fragment = lerp(tex2D(ReShade::BackBuffer, texcoord), lerp(tex2D(Otis_BloomSampler, texcoord), float4(FogColor, 1.0), fogFactor), fogFactor);
 }
 
 technique AdaptiveFog

--- a/Shaders/CinematicDOF.fx
+++ b/Shaders/CinematicDOF.fx
@@ -606,11 +606,11 @@ namespace CinematicDOF
 				float signedSampleRadius = tex2Dlod(SamplerCDCoC, tapCoords).x * radiusFactor;
 				float absoluteSampleRadius = abs(signedSampleRadius);
 				float isSamePlaneAsFragment = ((signedSampleRadius > 0 && !isNearPlaneFragment) || (signedSampleRadius <= 0 && isNearPlaneFragment));
-				float lumaWeight = saturate(1 - abs(absoluteFragmentRadius - absoluteSampleRadius));
-				float weight = lumaWeight * isSamePlaneAsFragment;
+				float lumaWeight = absoluteFragmentRadius - absoluteSampleRadius < 0.001;
+				float weight = saturate(1 - abs(absoluteFragmentRadius - absoluteSampleRadius)) * isSamePlaneAsFragment * lumaWeight;
 				float3 tap = tex2Dlod(source, tapCoords).rgb;
-				maxLuma = max(maxLuma, isSamePlaneAsFragment * dot(tap.rgb, lumaDotWeight) * lumaWeight * 
-									  (absoluteSampleRadius < 0.2 ? 0 : smoothstep(0, 1, saturate(absoluteSampleRadius-0.2)/0.8)));
+				maxLuma = max(maxLuma, isSamePlaneAsFragment * dot(tap.rgb, lumaDotWeight) * lumaWeight
+									* (absoluteSampleRadius < 0.2 ? 0 : smoothstep(0, 1, saturate(absoluteSampleRadius-0.2)/0.8)));
 				average.rgb += tap.rgb * weight;
 				average.w += weight;
 				angle+=anglePerPoint;

--- a/Shaders/CinematicDOF.fx
+++ b/Shaders/CinematicDOF.fx
@@ -605,7 +605,7 @@ namespace CinematicDOF
 				float isSamePlaneAsFragment = ((signedSampleRadius > 0 && !isNearPlaneFragment) || (signedSampleRadius <= 0 && isNearPlaneFragment));
 				float weight = saturate(1 - abs(absoluteFragmentRadius - signedSampleRadius)) * isSamePlaneAsFragment;
 				float3 tap = tex2Dlod(source, tapCoords).rgb;
-				maxLuma = max(maxLuma, isSamePlaneAsFragment * dot(tap.rgb, float3(0.3, 0.59, 0.11)) * (abs(signedSampleRadius) < 0.01 ? 0 : 1));
+				maxLuma = max(maxLuma, isSamePlaneAsFragment * dot(tap.rgb, float3(0.3, 0.59, 0.11)) * absoluteSampleRadius * (absoluteSampleRadius < 0.01 ? 0 : 1));
 				average.rgb += tap.rgb * weight;
 				average.w += weight;
 				angle+=anglePerPoint;

--- a/Shaders/CinematicDOF.fx
+++ b/Shaders/CinematicDOF.fx
@@ -450,7 +450,7 @@ namespace CinematicDOF
 	// to blend with.
 	float4 PerformNearPlaneDiscBlur(VSDISCBLURINFO blurInfo, sampler2D source)
 	{
-		const float lumaDotWeight = float3(0.3, 0.59, 0.11);
+		const float3 lumaDotWeight = float3(0.3, 0.59, 0.11);
 		float4 fragment = tex2Dlod(source, float4(blurInfo.texcoord, 0, 0));
 		// r contains blurred CoC, g contains original CoC. Original is negative.
 		float2 fragmentRadii = tex2Dlod(SamplerCDCoCBlurred, float4(blurInfo.texcoord, 0, 0)).rg;
@@ -524,7 +524,7 @@ namespace CinematicDOF
 	// Out: RGBA fragment that's the result of the disc-blur on the pixel at texcoord in source. A contains luma of pixel.
 	float4 PerformDiscBlur(VSDISCBLURINFO blurInfo, sampler2D source)
 	{
-		const float lumaDotWeight = float3(0.3, 0.59, 0.11);
+		const float3 lumaDotWeight = float3(0.3, 0.59, 0.11);
 		const float pointsFirstRing = 7; 	// each ring has a multiple of this value of sample points. 
 		float4 fragment = tex2Dlod(source, float4(blurInfo.texcoord, 0, 0));
 		float fragmentRadius = tex2Dlod(SamplerCDCoC, float4(blurInfo.texcoord, 0, 0)).r;
@@ -583,7 +583,7 @@ namespace CinematicDOF
 	// Out: RGBA fragment that's the result of the disc-blur on the pixel at texcoord in source. A contains luma of RGB.
 	float4 PerformPreDiscBlur(VSDISCBLURINFO blurInfo, sampler2D source)
 	{
-		const float lumaDotWeight = float3(0.3, 0.59, 0.11);
+		const float3 lumaDotWeight = float3(0.3, 0.59, 0.11);
 		const float radiusFactor = 1.0/5.0;
 		const float pointsFirstRing = 7; 	// each ring has a multiple of this value of sample points. 
 		float4 fragment = tex2Dlod(source, float4(blurInfo.texcoord, 0, 0));


### PR DESCRIPTION
One pr with bugfixes for 2 shaders

Adaptive Fog: fogstart now actually does what it should. Controls are now much easier to use as well. (as in: they're usable now)

Cinematic DOF: 
- Near plane blur is now resolution independent 
- Small tweak in luma constant usage (less constructor calls), pre-blur luma weight adjustment for out-of-focus areas
- Fixes bug in highlight bleeding due to pre-blur not masking enough.
- Small tweak in pre blur to mitigate highlight bleed in near-focus areas
- Average CoC calculation forgot central pixel 
- Combiner now uses full res for far plane if far plane blur is set to 0 so you can create screenshots with just near plane blur.
