### PR TITLE
Update Depth3D.fx

### DIFF
--- a/Shaders/Depth3D.fx
+++ b/Shaders/Depth3D.fx
@@ -26,25 +26,29 @@
 //USER EDITABLE PREPROCESSOR FUNCTIONS START//
 
 // Determines the Max Depth amount, in ReShades GUI.
-#define Depth_Max 52.5
+#define Depth_Max 50
+
+//Define Display aspect ratio for screen cursor. A 16:9 aspect ratio will equal (1.77:1)
+#define DAR float2(1.77, 1.0)
 
 //USER EDITABLE PREPROCESSOR FUNCTIONS END//
+
+#if !defined(__RESHADE__) || __RESHADE__ < 40000
+	#define Compatibility 1
+#else
+	#define Compatibility 0
+#endif
+
 //Divergence & Convergence//
 uniform float Divergence <
 	ui_type = "drag";
-	ui_min = 1; ui_max = Depth_Max;
+	ui_min = 1; ui_max = Depth_Max; ui_step = 0.5;
 	ui_label = "·Divergence·";
 	ui_tooltip = "Divergence increases differences between the left and right images, allows you to experience depth.\n" 
 				 "The process of deriving binocular depth information is called stereopsis.\n"
 				 "You can override this value, at an peformance cost.";
 	ui_category = "Divergence & Convergence";
 > = 25.0;
-
-uniform bool ZPD_GUIDE <
-	ui_label = " Convergence Guide";
-	ui_tooltip = "A Guide used to help adjust convergence.";
-	ui_category = "Divergence & Convergence";
-> = false;
 
 uniform float ZPD <
 	ui_type = "drag";
@@ -63,9 +67,9 @@ uniform float Auto_Depth_Range <
 	ui_min = 0.0; ui_max = 0.625;
 	ui_label = " Auto Depth Range";
 	ui_tooltip = "The Map Automaticly scales to outdoor and indoor areas.\n" 
-				 "Default is Zero, Zero is off.";
+				 "Default is 0.1f, Zero is off.";
 	ui_category = "Divergence & Convergence";
-> = 0.0;
+> = 0.1;
 
 //Depth Buffer Adjust//
 uniform int Depth_Map <
@@ -78,7 +82,7 @@ uniform int Depth_Map <
 
 uniform float Depth_Map_Adjust <
 	ui_type = "drag";
-	ui_min = 1.0; ui_max = 250.0;
+	ui_min = 1.0; ui_max = 250.0; ui_step = 0.125;
 	ui_label = " Z-Buffer Adjustment";
 	ui_tooltip = "This allows for you to adjust Depth Buffer Precision.\n"
 				 "Try to adjust this to keep it as low as possible.\n"
@@ -110,26 +114,45 @@ uniform bool Depth_Map_Flip <
 	ui_category = "Depth Buffer Adjust";
 > = false;
 
-//Weapon Hand Scale Options//
+//Weapon Hand Adjust//
+uniform bool WP <
+	ui_label = "·Weapon Hand Adjust·";
+	ui_tooltip = "Enables Weapon Hand Adjust for your game.";
+	ui_category = "Weapon Hand Adjust";
+> = false;
+
 uniform int Weapon_Scale <
+	#if Compatibility
 	ui_type = "drag";
-	ui_min = 0; ui_max = 2;
+	#else
+	ui_type = "slider";
+	#endif
+	ui_min = -3; ui_max = 3;
 	ui_label = " Weapon Scale";
 	ui_tooltip = "Use this to set the proper weapon hand scale.";
 	ui_category = "Weapon Hand Adjust";
 > = 0;
 
-uniform float3 Weapon_Adjust <
+uniform float2 Weapon_Adjust <
 	ui_type = "drag";
-	ui_min = 0.0; ui_max = 10.0;
+	ui_min = 0.0; ui_max = 25.0;
 	ui_label = " Weapon Hand Adjust";
 	ui_tooltip = "Adjust Weapon depth map for your games.\n"
-				 "X, The CutOff point used to set a diffrent depth scale for first person view.\n"
-				 "Y, The Power needed to scale the first person view apart from world scale.\n"
-				 "Z, Adjust is used to fine tune the first person view scale.\n"
-	             "Default is float3(X 0.0, Y 2.0, Z 1.5)";
+				 "X, CutOff Point used to set a diffrent scale for first person hand apart from world scale.\n"
+				 "Y, Precision is used to adjust the first person hand in world scale.\n"
+	             "Default is float2(X 0.0, Y 0.0)";
 	ui_category = "Weapon Hand Adjust";
-> = float3(0.0,2.0,1.5);
+> = float2(0.0,0.0);
+
+uniform float Weapon_Depth_Adjust <
+	ui_type = "drag";
+	ui_min = -50.0; ui_max = 50.0; ui_step = 0.25;
+	ui_label = " Weapon Depth Adjustment";
+	ui_tooltip = "Pushes or Pulls the FPS Hand in or out of the screen if a weapon profile is selected.\n"
+				 "This also used to fine tune the Weapon Hand if creating a weapon profile.\n" 
+				 "Default is Zero.";
+	ui_category = "Weapon Hand Adjust";
+> = 0;
 
 //Stereoscopic Options//
 uniform int Stereoscopic_Mode <
@@ -148,7 +171,7 @@ uniform float Anaglyph_Desaturation <
 	ui_category = "Stereoscopic Options";
 > = 1.0;
 
-uniform float Perspective <
+uniform int Perspective <
 	ui_type = "drag";
 	ui_min = -100; ui_max = 100;
 	ui_label = " Perspective Slider";
@@ -163,15 +186,27 @@ uniform bool Eye_Swap <
 	ui_category = "Stereoscopic Options";
 > = false;
 
-//Cursor Adjustments//
-uniform float4 Cross_Cursor_Adjust <
+//Crosshair Adjustments//
+uniform float3 Cursor_STT <
 	ui_type = "drag";
-	ui_min = 0.0; ui_max = 255.0;
-	ui_label = "·Cross Cursor Adjust·";
-	ui_tooltip = "Pick your own cross cursor color & Size.\n" 
-				 " Default is (R 255, G 255, B 255 , Size 25)";
+	ui_min = 0; ui_max = 1;
+	ui_label = " Crosshair Adjustments";
+	ui_tooltip = "This controlls the Size, Thickness, & Transparency.\n" 
+				 "Defaults are ( X 0.125, Y 0.5, Z 0.75 ).";
 	ui_category = "Cursor Adjustments";
-> = float4(255.0, 255.0, 255.0, 25.0);
+> = float3(0.125,0.5,0.75);
+
+uniform float3 Cursor_Color <
+	ui_type = "color";
+	ui_label = " Crosshair Color";
+	ui_category = "Cursor Adjustments";
+> = float3(1.0,1.0,1.0);
+
+uniform bool SCSC <
+	ui_label = " Cursor Lock";
+	ui_tooltip = "Screen Cursor to Screen Crosshair Lock.";
+	ui_category = "Cursor Adjustments";
+> = false;
 
 /////////////////////////////////////////////D3D Starts Here/////////////////////////////////////////////////////////////////
 #include "ReShade.fxh"
@@ -191,29 +226,28 @@ sampler BackBuffer
 	AddressW = BORDER;
 };	
 	
-texture texDepth  { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT * 0.5; Format = RGBA32F; MipLevels = 1;}; 
+texture texDepth  { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT ; Format = RGBA16F;}; 
 
 sampler SamplerDepth
 	{
 		Texture = texDepth;
-		MipLODBias = 1.0f;
 		MinFilter = LINEAR;
 		MagFilter = LINEAR;
 		MipFilter = LINEAR;
 	};
 	
-texture texDiso  { Width = BUFFER_WIDTH * 0.5; Height = BUFFER_HEIGHT * 0.5; Format = RGBA32F; MipLevels = 2;}; 
+texture texDiso  { Width = BUFFER_WIDTH ; Height = BUFFER_HEIGHT ; Format = RGBA16F; MipLevels = 1;}; 
 
 sampler SamplerDiso
 	{
 		Texture = texDiso;
-		MipLODBias = 2.0f;
+		MipLODBias = 1.0f;
 		MinFilter = LINEAR;
 		MagFilter = LINEAR;
 		MipFilter = LINEAR;
 	};
 
-texture texEncode  { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = RGBA32F; MipLevels = 1;}; 
+texture texEncode  { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; Format = RGBA16F; MipLevels = 1;};
 
 sampler SamplerEncode
 	{
@@ -226,14 +260,23 @@ sampler SamplerEncode
 
 uniform float2 Mousecoords < source = "mousepoint"; > ;	
 ////////////////////////////////////////////////////////////////////////////////////Cross Cursor////////////////////////////////////////////////////////////////////////////////////	
-float4 MouseCursor(float4 position : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+float4 MCursor(float4 position : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
 {
-	float2 MousecoordsXY = Mousecoords * pix;
-	float2 CC_Size = Cross_Cursor_Adjust.a * pix;
-	float2 CC_ModeA = float2(1.25,1.0), CC_ModeB = float2(0.5,0.5);
-	float4 Mpointer = all(abs(texcoord - MousecoordsXY) < CC_Size*CC_ModeA) * (1 - all(abs(texcoord - MousecoordsXY) > CC_Size/(Cross_Cursor_Adjust.a*CC_ModeB))) ? float4(Cross_Cursor_Adjust.rgb/255, 1.0) : tex2D(BackBuffer, texcoord);//cross
+	float CCA = 0.1,CCB = 0.0025, CCC = 0.025, CCD = 0.05;
+	float2 MousecoordsXY = Mousecoords * pix, center = texcoord, Screen_Ratio = float2(DAR.x,DAR.y), Size_Thickness = float2(Cursor_STT.x,Cursor_STT.y + 0.00000001);
 	
-	return Mpointer;
+	if (SCSC)
+	MousecoordsXY = float2(0.5,0.5);
+	
+	float dist_fromHorizontal = abs(center.x - MousecoordsXY.x) * Screen_Ratio.x, Size_H = Size_Thickness.x * CCA, THICC_H = Size_Thickness.y * CCB;
+	float dist_fromVertical = abs(center.y - MousecoordsXY.y) * Screen_Ratio.y , Size_V = Size_Thickness.x * CCA, THICC_V = Size_Thickness.y * CCB;	
+	
+	//Cross Cursor
+	float B = min(max(THICC_H - dist_fromHorizontal,0)/THICC_H,max(Size_H-dist_fromVertical,0));
+	float A = min(max(THICC_V - dist_fromVertical,0)/THICC_V,max(Size_V-dist_fromHorizontal,0));
+	float CC = A+B; //Cross Cursor
+		
+	return lerp( CC  ? float4(Cursor_Color.rgb, 1.0) : tex2D(BackBuffer, texcoord),tex2D(BackBuffer, texcoord),1-Cursor_STT.z);
 }
 /////////////////////////////////////////////////////////////////////////////////Adapted Luminance/////////////////////////////////////////////////////////////////////////////////
 texture texLumi {Width = 256*0.5; Height = 256*0.5; Format = RGBA8; MipLevels = 8;}; //Sample at 256x256/2 and a mip bias of 8 should be 1x1 
@@ -256,70 +299,135 @@ float Lumi(in float2 texcoord : TEXCOORD0)
 	
 /////////////////////////////////////////////////////////////////////////////////Depth Map Information/////////////////////////////////////////////////////////////////////////////////
 
-float NearestScaled( float DM )
-{
-	float WDM = DM, Nearest_Scaled = Weapon_Adjust.y, Scale_Adjust = Weapon_Adjust.z,CutOff = Weapon_Adjust.x/100, Set_Scale;
-	
-	if (Weapon_Scale == 0)
-	{
-		Nearest_Scaled = 0.001/(Nearest_Scaled*0.5);
-		Scale_Adjust = Scale_Adjust * 1.5;
-		Set_Scale = 7.5;
-	}
-	else if (Weapon_Scale == 1)
-	{
-		Nearest_Scaled = 0.0001/(Nearest_Scaled*0.5);
-		Scale_Adjust = Scale_Adjust * 6.25;
-		Set_Scale = 5.625;
-	}
-	else if (Weapon_Scale == 2)
-	{
-		Nearest_Scaled = 0.00001/(Nearest_Scaled*0.5);
-		Scale_Adjust = Scale_Adjust * 50.0;
-		Set_Scale = 3.75;
-	}
+float Depth(in float2 texcoord : TEXCOORD0)
+{	
+	if (Depth_Map_Flip)
+		texcoord.y =  1 - texcoord.y;
+		
+	float zBuffer = tex2D(DepthBuffer, texcoord).x, DMA = Depth_Map_Adjust; //Depth Buffer
 
-	WDM = (smoothstep(0,1,WDM) / Nearest_Scaled ) - Scale_Adjust;
 	
-	float Far = 1, Near = 0.125/Set_Scale;
+	//Conversions to linear space.....
+	//Near & Far Adjustment
+	float Far = 1.0, Near = 0.125/DMA; //Division Depth Map Adjust - Near
 	
-	WDM = Far * Near / (Far + WDM * (Near - Far));
-    
-	float Merge = lerp(DM,WDM,step(DM,CutOff)); //Cutoff point
-	Merge = lerp(Merge,DM,0.250);
-	return  Merge;
+	float2 Offsets = float2(1 + Offset,1 - Offset), Z = float2( zBuffer, 1-zBuffer );
+	
+	if (Offset > 0)
+	Z = min( 1, float2( Z.x*Offsets.x , Z.y /  Offsets.y  ));
+		
+	if (Depth_Map == 0)//DM0. Normal
+		zBuffer = Far * Near / (Far + Z.x * (Near - Far));		
+	else if (Depth_Map == 1)//DM1. Reverse
+		zBuffer = Far * Near / (Far + Z.y * (Near - Far));
+			
+	return zBuffer;
+}
+
+float2 WeaponDepth(in float2 texcoord : TEXCOORD0)
+{
+	if (Depth_Map_Flip)
+	texcoord.y =  1 - texcoord.y;
+		
+	float zBufferWH = tex2D(DepthBuffer, texcoord).x, CutOff = Weapon_Adjust.x , Adjust = Weapon_Adjust.y, Tune = Weapon_Depth_Adjust, Scale = Weapon_Scale;
+	
+	float4 WA_XYZW;//Weapon Profiles Starts Here
+	if (WP == 1)                                   // WA_XYZW.x | WA_XYZW.y | WA_XYZW.z | WA_XYZW.w 
+		WA_XYZW = float4(CutOff,Adjust,Tune,Scale);// X Cutoff  | Y Adjust  | Z Tuneing | W Scaling 		
+	
+	// Code Adjustment Values.
+	// WA_XYZW.x | WA_XYZW.y | WA_XYZW.z | WA_XYZW.w 
+	// X Cutoff  | Y Adjust  | Z Tuneing | W Scaling 	
+	
+	// Hear on out is the Weapon Hand Adjustment code.		
+	float Set_Scale , P = WA_XYZW.y;
+	
+	if (WA_XYZW.w == -3)
+	{
+		WA_XYZW.x *= 21.0f;
+		P = (P + 0.00000001) * 100;
+		Set_Scale = 0.5f;
+	}			
+	if (WA_XYZW.w == -2)
+	{
+		P = (P + 0.00000001) * 100;
+		Set_Scale = 0.5f;
+	}
+	else if (WA_XYZW.w == -1)
+	{
+		Set_Scale = 0.332;
+		P = (P + 0.00000001) * 100;
+	}
+	else if (WA_XYZW.w == 0)
+	{
+		Set_Scale = 0.105;
+		P = (P + 0.00000001) * 100;
+	}
+	else if (WA_XYZW.w == 1)
+	{
+		Set_Scale = 0.07265625;
+		P = (P + 0.00000001) * 100;
+	}
+	else if (WA_XYZW.w == 2)
+	{
+		Set_Scale = 0.0155;
+		P = (P + 0.00000001) * 2000;
+	}	
+	else if (WA_XYZW.w == 3)
+	{
+		Set_Scale = 0.01;
+		P = (P + 0.00000001) * 100;
+	}
+	//FPS Hand Depth Maps require more precision at smaller scales to look right.		 		
+	float Far = (P * Set_Scale) * (1+(WA_XYZW.z * 0.01f)), Near = P;
+	
+	float2 Z = float2( zBufferWH, 1-zBufferWH );
+			
+	if ( Depth_Map == 0 )
+		zBufferWH /= Far - Z.x * (Near - Far);
+	else if ( Depth_Map == 1 )
+		zBufferWH /= Far - Z.y * (Near - Far);
+	
+	zBufferWH = saturate(zBufferWH);
+	
+	//This code is used to adjust the already set Weapon Hand Profile.
+	float WA = 1 + (Weapon_Depth_Adjust * 0.015);
+	if (WP > 1)
+	zBufferWH = (zBufferWH - 0) /  (WA - 0);
+	
+	//Auto Anti Weapon Depth Map Z-Fighting is always on.
+	float WeaponLumAdjust = saturate(abs(smoothstep(0,0.5,Lumi(texcoord)*2.5)));	
+			
+	//Anti Weapon Hand Z-Fighting code trigger
+	//if (WP > 1)
+	zBufferWH = saturate(lerp(0.025, zBufferWH, saturate(WeaponLumAdjust)));
+				
+	return float2(zBufferWH.x,WA_XYZW.x);	
 }
 
 void DepthMap(in float4 position : SV_Position, in float2 texcoord : TEXCOORD0, out float4 Color : SV_Target)
 {		
-	float R,G,B,A = 1.0;
-	if (Depth_Map_Flip)
-		texcoord.y =  1 - texcoord.y;
+		float4 DM = Depth(texcoord).xxxx;
 		
-	float zBuffer = tex2D(DepthBuffer, texcoord).r; //Depth Buffer
-
-	//Conversions to linear space.....
-	//Near & Far Adjustment
-	float Far = 1, Near = 0.125/Depth_Map_Adjust, NearLocked = 0.125/7.5; //Division Depth Map Adjust - Near
-	
-	float2 DM, Offsets = float2(1 + Offset,1 - Offset), Z = float2( zBuffer, 1 - zBuffer );
-	
-	if (Offset > 0)
-	Z = min( 1, float2( Z.x*Offsets.x , ( Z.y - 0.0 ) / ( Offsets.y - 0.0 ) ) );
-	
-	if (Depth_Map == 0) //DM0. Normal
-	{
-		DM = float2( 2.0 * Near * Far / (Far + Near - pow(abs(Z.x),2) * (Far - Near)), 2.0 * NearLocked * Far / (Far + NearLocked - pow(abs(Z.x),2) * (Far - NearLocked)) );
-	}		
-	else //DM1. Reverse
-	{
-		DM = float2( 2.0 * Near * Far / (Far + Near - pow(abs(Z.y),1.375) * (Far - Near)) , 2.0 * NearLocked * Far / (Far + NearLocked - pow(abs(Z.y),1.375) * (Far - NearLocked)) );
-	}
-	
-	R = saturate(DM.x);
-	G = saturate(NearestScaled(DM.y));
-	
-	Color = float4(R,G,B,A);
+		float DMA = Depth_Map_Adjust;
+		
+		float R, G, B, A, WD = WeaponDepth(texcoord).x, CoP = WeaponDepth(texcoord).y, CutOFFCal = (CoP / DMA) * 0.5f; //Weapon Cutoff Calculation
+		
+		CutOFFCal = step(DM.x,CutOFFCal);
+					
+		if (WP == 0)
+		{
+			DM.x = DM.x;
+		}
+		else
+		{
+			DM.x = lerp(DM.x,WD,CutOFFCal);
+		}
+		
+		R = DM.x; //Mix Depth
+		A = DM.w; //AverageLuminance
+				
+	Color = saturate(float4(R,G,B,A));
 }
 
 float AutoDepthRange( float d, float2 texcoord )
@@ -328,43 +436,29 @@ float AutoDepthRange( float d, float2 texcoord )
     return min(1,( d - 0 ) / ( LumAdjust - 0));
 }
 
-float Conv(float2 DM_IN,float2 texcoord)
+float Conv(float DM,float2 texcoord)
 {
-	float DM, Convergence, Z = ZPD, ZP = 0.54875f;
+	float Z = ZPD, ZP = 0.54875f;
+				
+		if (ZPD == 0)
+			ZP = 1.0f;
 		
-	if (Auto_Depth_Range > 0)
-	{
-		DM_IN.x = AutoDepthRange(DM_IN.x,texcoord);
-		DM_IN.y = AutoDepthRange(DM_IN.y,texcoord);
-	}
-	
-	if (ZPD == 0)
-		ZP = 1.0;
-		
-	// You need to readjust the Z-Buffer if your going to use use the Convergence equation.
-	float2 DMC = DM_IN.xy/(1-Z);		
-					
-	float Convergence_A = 1 - Z / DMC.x;		
-	float Convergence_B = 1 - Z / DMC.y;
-			  
-	if (Weapon_Adjust.x > 0)
-		Convergence_A = Convergence_B;
-	
-	DM = DM_IN.x;		
-	Convergence	= Convergence_A;
-		
-	Z = lerp(Convergence,DM, ZP);
-		
+		if (Auto_Depth_Range > 0)
+			DM = AutoDepthRange(DM,texcoord);
+								
+		float Convergence = 1 - Z / DM;
+									
+		Z = lerp(Convergence,DM, ZP);
+				
     return Z;
 }
 
 void  Disocclusion(in float4 position : SV_Position, in float2 texcoord : TEXCOORD0, out float4 color : SV_Target0)
 {
-float A, S, MS =  Divergence * pix.x, Div = 1.0f / 7.0f;
-float2 DM, dir;
+	float DM, A, S, MS =  (Divergence * 0.875f) * pix.x, Div = 1.0f / 7.0f, MA = 2.0 , M = distance(1.0f , tex2Dlod(SamplerDepth,float4(texcoord,0,0)).w), Mask = saturate(M * MA - 1.0f) > 0.0f;
 	
 	A += 5.5; // Normal
-	dir = float2(0.5,0.0);	
+	float2 dir = float2(0.5,0.0);	
 	
 	const float weight[7] = {0.0f,0.0125f,-0.0125f,0.0375f,-0.0375f,0.05f,-0.05f};
 				
@@ -372,39 +466,43 @@ float2 DM, dir;
 	for (int i = 0; i < 7; i++)
 	{	
 		S = weight[i] * MS;
-		DM += tex2Dlod(SamplerDepth,float4(texcoord + dir * S * A,0,1)).xy*Div;
+		DM += tex2Dlod(SamplerDepth,float4(texcoord + dir * S * A,0,0)).x*Div;
 	}
 	
-	color = float4(DM.x,DM.y,0,1.0);
+	DM = lerp(lerp(tex2Dlod(SamplerDepth,float4(texcoord,0,0)).w, DM, abs(Mask)), DM, 0.625f );
+	
+	color = float4(DM,0,0,1.0);
 }
 
 /////////////////////////////////////////L/R//////////////////////////////////////////////////////////////////////
 
 void Encode(in float4 position : SV_Position, in float2 texcoord : TEXCOORD0, out float4 color : SV_Target0) //zBuffer Color Channel Encode
 {
-	float2 DepthL = 1.0, DepthR = 1.0;
-	float samples[3] = {0.5f,0.75f,1.0f}, MSL = (Divergence * 0.25f) * pix.x, S, MS = Divergence * pix.x;
-		[loop]
-	for ( int i = 0 ; i < 3; i++ ) 
-	{
-		S = samples[i] * MSL;
-		DepthL = min(DepthL,tex2Dlod(SamplerDiso, float4(texcoord.x - S, texcoord.y,0,0)).xy);
-		DepthR = min(DepthR,tex2Dlod(SamplerDiso, float4(texcoord.x + S, texcoord.y,0,0)).xy);
-	}
+	float MSL, N = 3, samples[3] = {0.5f,0.75f,1.0f};
 	
-	// X Left & Y Right
-	float X = texcoord.x + MS * Conv(DepthL,texcoord), Y = (1 - texcoord.x) + MS * Conv(DepthR,texcoord);
+	float DepthR = 1.0f, DepthL = 1.0f, MS = Divergence * pix.x;
+	
+	[loop]
+	for ( int i = 0 ; i < N; i++ ) 
+	{
+		MSL = Divergence * 0.1875f;
+		DepthL = min(DepthL,tex2Dlod(SamplerDiso, float4(texcoord.x - (samples[i] * MSL) * pix.x, texcoord.y,0,0)).x);
+		DepthR = min(DepthR,tex2Dlod(SamplerDiso, float4(texcoord.x + (samples[i] * MSL) * pix.x, texcoord.y,0,0)).x);
+	}	
 
-	color = float4(X,Y,0.0,1.0);
+	// X Right & Y Left
+	float X = Conv(DepthL,texcoord), Y = Conv(DepthR,texcoord), Z = Conv(tex2Dlod(SamplerDiso,float4(texcoord,0,0)).x,texcoord);
+	color = float4(X,Y,Z,1.0);
 }
 
-float2 Decode(in float2 texcoord : TEXCOORD0)
+float3 Decode(in float2 texcoord : TEXCOORD0)
 {
-	float3 X = abs(tex2Dlod(SamplerEncode,float4(texcoord,0,0)).xxx), Y = abs(tex2Dlod(SamplerEncode,float4(texcoord,0,0)).yyy);
-	float ByteN = 640; //Byte Shift for Debanding depth buffer in final 3D image.
+	float MS = Divergence * pix.x, ByteN = 384; //Byte Shift for Debanding depth buffer in final 3D image.
+	float3 ZB = tex2Dlod(SamplerEncode,float4(texcoord,0,0)).xyz, X = texcoord.x + MS * ZB.xxx, Y = (1 - texcoord.x) + MS * ZB.yyy, Z = ZB.zzz;
 	float A = dot(X, float3(1.0f, 1.0f / ByteN, 1.0f / (ByteN * ByteN)) ); //byte_to_float
 	float B = dot(Y, float3(1.0f, 1.0f / ByteN, 1.0f / (ByteN * ByteN)) ); //byte_to_float
-	return float2(A,B);
+	float C = dot(Z, float3(1.0f, 1.0f / ByteN, 1.0f / (ByteN * ByteN)) ); //byte_to_float
+	return float3(A,B,C);
 }
 
 float4 PS_calcLR(float2 texcoord)
@@ -412,8 +510,8 @@ float4 PS_calcLR(float2 texcoord)
 	float2 TCL, TCR, TexCoords = texcoord;
 	float4 color, Right, Left;
 	
-	//P is Perspective Adjustment.	
-	float P = Perspective * pix.x, N, S;
+	//MS is Max Seperation and P is Perspective Adjustment.	
+	float MS = Divergence * pix.x, P = Perspective * pix.x, N, S;
 						
 	if(Eye_Swap)
 	{
@@ -451,39 +549,22 @@ float4 PS_calcLR(float2 texcoord)
 			TCR = float2(texcoord.x - P,texcoord.y);
 		}
 	}
-		
-	//Optimization for line & column interlaced out.
-	if (Stereoscopic_Mode == 2)
-	{
-		TCL.y = TCL.y + (0.25f * pix.y);
-		TCR.y = TCR.y - (0.25f * pix.y);
-	}
-	else if (Stereoscopic_Mode == 3)
-	{
-		TCL.x = TCL.x + (0.25f * pix.x);
-		TCR.x = TCR.x - (0.25f * pix.x);
-	}
 	
-	if(ZPD_GUIDE == 1)
-	{
-		Left = 0.0f;
-		Right = 0.0f;
-	}
-	else
-	{
-		Left = tex2Dlod(BackBuffer, float4(TCL,0,0));
-		Right = tex2Dlod(BackBuffer, float4(TCR,0,0));
-	}	
+		float CCL = -MS * Decode(float2(TCL.x + (Divergence * 0.1875) * pix.x, TCL.y)).z;
+		float CCR = -MS * Decode(float2(TCR.x - (Divergence * 0.1875) * pix.x, TCR.y)).z;
+		
+		Left = tex2Dlod(BackBuffer, float4(TCL.x + CCL, TCL.y,0,0));
+		Right = tex2Dlod(BackBuffer, float4(TCR.x - CCR, TCR.y,0,0));
 		
 		[loop]
 		for (int i = 0; i < Divergence + 5; i++) 
 		{
 			//L
-			[flatten] if( Decode(float2(TCL.x+i*pix.x,TCL.y)).y > (1-TCL.x)-pix.x * 5 )
+			if( Decode(float2(TCL.x+i*pix.x,TCL.y)).y >= (1-TCL.x)-pix.x )
 						Left = tex2Dlod(BackBuffer, float4(TCL.x + i * pix.x, TCL.y,0,0));
 			
 			//R
-			[flatten] if( Decode(float2(TCR.x-i*pix.x,TCR.y)).x > TCR.x-pix.x * 5 )
+			if( Decode(float2(TCR.x-i*pix.x,TCR.y)).x >= TCR.x-pix.x )
 						Right = tex2Dlod(BackBuffer, float4(TCR.x - i * pix.x, TCR.y,0,0));
 		}		
 	
@@ -578,10 +659,8 @@ float4 PS_calcLR(float2 texcoord)
 	}
 		else
 	{		
-			float R = tex2Dlod(SamplerDepth,float4(TexCoords.x, TexCoords.y,0,0)).x;
-			float G = AutoDepthRange(tex2Dlod(SamplerDepth,float4(TexCoords.x, TexCoords.y,0,0)).x,TexCoords);
-			float B = tex2Dlod(SamplerDiso,float4(TexCoords.x,TexCoords.y,0,0)).g;
-			color = float4(R,G,B,1.0);
+			float3 RGB = tex2Dlod(SamplerDiso,float4(TexCoords.x, TexCoords.y,0,0)).xxx;
+			color = float4(RGB.r,AutoDepthRange(RGB.g,TexCoords),RGB.b,1.0);
 	}
 
 	return float4(color.rgb,1.0);
@@ -589,7 +668,7 @@ float4 PS_calcLR(float2 texcoord)
 
 float4 Average_Luminance(float4 position : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
 {
-	float3 Average_Lum = tex2D(SamplerDepth,float2(texcoord.x,texcoord.y)).xxx;
+	float3 Average_Lum = tex2D(SamplerDepth,float2(texcoord.x,texcoord.y)).www;
 	return float4(Average_Lum,1.0);
 }
 
@@ -698,13 +777,13 @@ float4 Out(float4 position : SV_Position, float2 texcoord : TEXCOORD) : SV_Targe
 
 //*Rendering passes*//
 
-technique Cross_Cursor
+technique Crosshair
 {			
-			pass Cursor
-		{
-			VertexShader = PostProcessVS;
-			PixelShader = MouseCursor;
-		}	
+		pass CrossCursor
+	{
+		VertexShader = PostProcessVS;
+		PixelShader = MCursor;
+	}	
 }
 
 technique Depth3D


### PR DESCRIPTION
+Reshade 4.0.0 Compatibility Mode
+Corrected the problem with Vertical Artifact Banding. Should be a clearer image now.
+Small Performance boost from a little more efficient code and RGBA16F texture format.
+Auto Depth Range New Default
+Flushed out Weapon Hand Adjust. NearestScaled made to match my main shaders.
+Flushed out 3D Crosshair/Cursor Updated as it's necessary in some game to navigate.
+Convergence Changed and now fulling working. This made ZPD_GUIDE obsolete.
+Added ui_step to some adjustment to smooth trastions to reshade 4.0.0
+Also attempted to retain compatablity with older version of ReShade 3.0.0

Attempted to use RGBA8 since its seems be the fastest format available to me. But, RGBA8 is not cutting it due to precision limitations.

So I am switching over to RGBA16F and staying away from RGBA32F. Since RGBA32F is hard on GPUS.