### PR TITLE
Add a new depth present type "Show both"

### DIFF
--- a/Shaders/DisplayDepth.fx
+++ b/Shaders/DisplayDepth.fx
@@ -60,7 +60,7 @@ uniform int iUIPresentType <
 	ui_category = "Options";
 	ui_type = "combo";
 	ui_label = "Present type";
-	ui_items = "Depth map\0Normal map\0Show both(Vertical 50/50)\0";
+	ui_items = "Depth map\0Normal map\0Show both (Vertical 50/50)\0";
 > = 2;
 
 float GetDepth(float2 texcoord)

--- a/Shaders/DisplayDepth.fx
+++ b/Shaders/DisplayDepth.fx
@@ -60,8 +60,8 @@ uniform int iUIPresentType <
 	ui_category = "Options";
 	ui_type = "combo";
 	ui_label = "Present type";
-	ui_items = "Depth map\0Normal map\0";
-> = 1;
+	ui_items = "Depth map\0Normal map\0Show both(Vertical 50/50)\0";
+> = 2;
 
 float GetDepth(float2 texcoord)
 {
@@ -111,37 +111,41 @@ float3 NormalVector(float2 texcoord)
 
 void PS_DisplayDepth(in float4 position : SV_Position, in float2 texcoord : TEXCOORD0, out float3 color : SV_Target)
 {
+	float3 normal_color = NormalVector(texcoord);
+	
 	if(iUIPresentType == 1)
 	{
-		color = NormalVector(texcoord);
+		color = normal_color;
+		return;
 	}
-	else
+
+	const float dither_bit = 8.0; //Number of bits per channel. Should be 8 for most monitors.
+
+	/*------------------------.
+	| :: Ordered Dithering :: |
+	'------------------------*/
+	//Calculate grid position
+	float grid_position = frac(dot(texcoord, (ReShade::ScreenSize * float2(1.0 / 16.0, 10.0 / 36.0)) + 0.25));
+
+	//Calculate how big the shift should be
+	float dither_shift = 0.25 * (1.0 / (pow(2, dither_bit) - 1.0));
+
+	//Shift the individual colors differently, thus making it even harder to see the dithering pattern
+	float3 dither_shift_RGB = float3(dither_shift, -dither_shift, dither_shift); //subpixel dithering
+
+	//modify shift acording to grid position.
+	dither_shift_RGB = lerp(2.0 * dither_shift_RGB, -2.0 * dither_shift_RGB, grid_position); //shift acording to grid position.
+
+	//shift the color by dither_shift
+	float3 depth_color = GetDepth(texcoord).rrr + dither_shift_RGB;
+
+	if(iUIPresentType == 0)
 	{
-		color.rgb = GetDepth(texcoord).rrr;
-
-		const float dither_bit = 8.0; //Number of bits per channel. Should be 8 for most monitors.
-
-		//color = (tex.x*0.3+0.1); //draw a gradient for testing.
-		//#define dither_method 2 //override method for testing purposes
-
-		/*------------------------.
-		| :: Ordered Dithering :: |
-		'------------------------*/
-		//Calculate grid position
-		float grid_position = frac(dot(texcoord, (ReShade::ScreenSize * float2(1.0 / 16.0, 10.0 / 36.0)) + 0.25));
-
-		//Calculate how big the shift should be
-		float dither_shift = 0.25 * (1.0 / (pow(2, dither_bit) - 1.0));
-
-		//Shift the individual colors differently, thus making it even harder to see the dithering pattern
-		float3 dither_shift_RGB = float3(dither_shift, -dither_shift, dither_shift); //subpixel dithering
-
-		//modify shift acording to grid position.
-		dither_shift_RGB = lerp(2.0 * dither_shift_RGB, -2.0 * dither_shift_RGB, grid_position); //shift acording to grid position.
-
-		//shift the color by dither_shift
-		color.rgb += dither_shift_RGB;
+		color = depth_color;
+		return;
 	}
+	
+	color = lerp(normal_color, depth_color, step(ReShade::ScreenSize.x / 2, position.x));
 }
 
 technique DisplayDepth <


### PR DESCRIPTION
At the ReShade version reached 4.0, DisplayDepth has updated of setting method the preprocessor.
But some users misunderstand the depth preview because there are not leaned what about the correct display results of normal map.

This request contain that changes to display a preview of depth maps on each of split screen areas.

For users, do edit the settings until both depth effects are displayed on the each screen areas.

Add a new present type "Show both(Vertical 50/50)"
![show_both](https://user-images.githubusercontent.com/42232001/50636078-0e3f8400-0f98-11e9-8c3a-a9688a133225.png)

Not effective
![ffxiv_20190103_173026](https://user-images.githubusercontent.com/42232001/50636081-139cce80-0f98-11e9-88c5-344cfb72b000.png)

Preprocessor settings is wrong (_REVERSED)
![ffxiv_20190103_172831](https://user-images.githubusercontent.com/42232001/50636085-17c8ec00-0f98-11e9-9c96-43848a31e007.png)

Preprocessor settings is correct
![ffxiv_20190103_172701](https://user-images.githubusercontent.com/42232001/50636089-1992af80-0f98-11e9-8759-5499d3dfe1fd.png)
