### PR TITLE
Update to Perfect Perspective

### DIFF
--- a/Shaders/PerfectPerspective.fx
+++ b/Shaders/PerfectPerspective.fx
@@ -100,8 +100,7 @@ uniform bool DebugPreview <
 uniform int2 ResScale <
 	ui_label = "Super Resolution Scale";
 	ui_tooltip = "Simulates application running beyond\n"
-		"native screen resolution (using VSR or DSR)\n"
-		"\n"
+		"native screen resolution (using VSR or DSR)\n\n"
 		" First value  - screen resolution\n"
 		" Second value - virtual super resolution";
 	ui_type = "drag";

--- a/Shaders/PerfectPerspective.fx
+++ b/Shaders/PerfectPerspective.fx
@@ -9,7 +9,7 @@ http://creativecommons.org/licenses/by-nc-nd/4.0/
 For inquiries please contact jakubfober@gmail.com
 */
 
-// Perfect Perspective PS ver. 2.5.0
+// Perfect Perspective PS ver. 2.5.1
 
 
   ////////////////////
@@ -32,8 +32,13 @@ uniform int Projection <
 uniform int FOV <
 	ui_label = "Corrected Field of View";
 	ui_tooltip = "This setting should match your in-game Field of View";
-	ui_type = "drag";
-	ui_min = 45; ui_max = 120; ui_step = 0.2;
+	#if __RESHADE__ < 40000
+		ui_type = "drag";
+		ui_step = 0.2;
+	#else
+		ui_type = "slider";
+	#endif
+	ui_min = 0; ui_max = 170;
 	ui_category = "Distortion Correction";
 > = 90;
 
@@ -41,7 +46,11 @@ uniform float Vertical <
 	ui_label = "Vertical Curviness Amount";
 	ui_tooltip = "0.0 - cylindrical projection\n"
 		"1.0 - spherical projection";
-	ui_type = "drag";
+	#if __RESHADE__ < 40000
+		ui_type = "drag";
+	#else
+		ui_type = "slider";
+	#endif
 	ui_min = 0.0; ui_max = 1.0;
 	ui_category = "Distortion Correction";
 > = 0.5;
@@ -62,7 +71,7 @@ uniform float Zooming <
 	ui_label = "Borders Scale";
 	ui_tooltip = "Adjust image scale and cropped area";
 	ui_type = "drag";
-	ui_min = 0.0; ui_max = 3.0; ui_step = 0.001;
+	ui_min = 0.5; ui_max = 2.0; ui_step = 0.001;
 	ui_category = "Borders Settings";
 > = 1.0;
 

--- a/Shaders/PerfectPerspective.fx
+++ b/Shaders/PerfectPerspective.fx
@@ -2,42 +2,57 @@
 Copyright (c) 2018 Jacob Maximilian Fober
 
 This work is licensed under the Creative Commons 
-Attribution-ShareAlike 4.0 International License. 
+Attribution-NonCommercial-NoDerivatives 4.0 International License. 
 To view a copy of this license, visit 
-http://creativecommons.org/licenses/by-sa/4.0/.
+http://creativecommons.org/licenses/by-nc-nd/4.0/ 
+
+For inquiries please contact jakubfober@gmail.com
 */
 
-// Perfect Perspective PS ver. 2.4.1
+// Perfect Perspective PS ver. 2.5.0
+
 
   ////////////////////
  /////// MENU ///////
 ////////////////////
 
-#ifndef ShaderAnalyzer
+uniform int Projection <
+	ui_label = "Type of projection";
+	ui_tooltip = "Stereographic projection (shapes) preserves angles and proportions,\n"
+		"best for navigation through tight space.\n\n"
+		"Equisolid projection (size) preserves surface relations,\n"
+		"Best for open areas.\n\n"
+		"Equidistant maintains angular speed of motion,\n"
+		"best for chasing fast targets.";
+	ui_type = "combo";
+	ui_items = "Stereographic (shapes)\0Equisolid (size)\0Equidistant (speed)\0";
+	ui_category = "Distortion Correction";
+> = 0;
+
 uniform int FOV <
 	ui_label = "Corrected Field of View";
-	ui_tooltip = "This setting should match \n"
-		"your in-game Field of View";
-	ui_type = "slider";
+	ui_tooltip = "This setting should match your in-game Field of View";
+	ui_type = "drag";
 	ui_min = 45; ui_max = 120; ui_step = 0.2;
 	ui_category = "Distortion Correction";
 > = 90;
 
 uniform float Vertical <
 	ui_label = "Vertical Curviness Amount";
-	ui_tooltip = "1  -  Spherical projection \n"
-		"0  -  Cylindrical projection";
-	ui_type = "slider";
-	ui_min = 0.0; ui_max = 1.0; ui_step = 0.1;
+	ui_tooltip = "0.0 - cylindrical projection\n"
+		"1.0 - spherical projection";
+	ui_type = "drag";
+	ui_min = 0.0; ui_max = 1.0;
 	ui_category = "Distortion Correction";
 > = 0.5;
 
 uniform int Type <
 	ui_label = "Type of FOV (Field of View)";
-	ui_tooltip = "If the image bulges in movement (too high FOV), \n"
+	ui_tooltip = "In stereographic mode:\n\n"
+		"If image bulges in movement (too high FOV), \n"
 		"change it to 'Diagonal'.\n"
 		"When proportions are distorted at the periphery \n"
-		"(too low FOV), choose 'Vertical'";
+		"(too low FOV), choose 'Vertical'.";
 	ui_type = "combo";
 	ui_items = "Horizontal FOV\0Diagonal FOV\0Vertical FOV\0";
 	ui_category = "Distortion Correction";
@@ -45,48 +60,46 @@ uniform int Type <
 
 uniform float Zooming <
 	ui_label = "Borders Scale";
-	ui_tooltip = "Adjust image scale to see cropped areas";
-	ui_type = "slider";
+	ui_tooltip = "Adjust image scale and cropped area";
+	ui_type = "drag";
 	ui_min = 0.0; ui_max = 3.0; ui_step = 0.001;
 	ui_category = "Borders Settings";
 > = 1.0;
 
-uniform float4 Color <
+uniform float4 BorderColor <
 	ui_label = "Color of Borders";
-	ui_tooltip = "Use Alpha to adjust opacity";
-	ui_type = "Color";
+	ui_tooltip = "Use Alpha to change transparency";
+	ui_type = "color";
 	ui_category = "Borders Settings";
 > = float4(0.027, 0.027, 0.027, 0.0);
 
-uniform bool Borders <
+uniform bool MirrorBorders <
 	ui_label = "Mirrored Borders";
-	ui_tooltip = "Choose between original or mirrored\n"
-		"image at the borders";
+	ui_tooltip = "Choose original or mirrored image at the borders";
 	ui_category = "Borders Settings";
 > = true;
 
-uniform bool Debug <
+uniform bool DebugPreview <
 	ui_label = "Display Resolution Scale Map";
-	ui_tooltip = "Color map of the Resolution Scale \n"
-		" Red    -  Undersampling \n"
-		" Green  -  Supersampling \n"
-		" Blue   -  Neutral sampling";
+	ui_tooltip = "Color map of the Resolution Scale:\n\n"
+		" Red   - undersampling\n"
+		" Green - supersampling\n"
+		" Blue  - neutral sampling";
 	ui_category = "Debug Tools";
 > = false;
 
 uniform int2 ResScale <
-	ui_label = "D.S.R. Scale Factor";
-	ui_tooltip = "Dynamic Super Resolution (DSR), \n"
-		"simulates application running beyond\n"
-		"native screen resolution\n"
+	ui_label = "Super Resolution Scale";
+	ui_tooltip = "Simulates application running beyond\n"
+		"native screen resolution (using VSR or DSR)\n"
 		"\n"
-		"First Value - Native Screen Resolution\n"
-		"Second Value - D.S.R. Scaled Resolution";
-	ui_type = "slider";
+		" First value  - screen resolution\n"
+		" Second value - virtual super resolution";
+	ui_type = "drag";
 	ui_min = 16; ui_max = 16384; ui_step = 0.2;
 	ui_category = "Debug Tools";
 > = int2(1920, 1920);
-#endif
+
 
   //////////////////////
  /////// SHADER ///////
@@ -102,17 +115,36 @@ sampler SamplerColor
 	AddressV = MIRROR;
 };
 
-// Stereographic-Gnomonic lookup function by Jacob Max Fober
+// Convert RGB to grayscale
+float Grayscale(float3 Color)
+{ return max(max(Color.r,Color.g),Color.b); }
+
+// Perspective lookup functions by Jacob Max Fober
 // Input data:
 	// FOV >> Camera Field of View in degrees
 	// Coordinates >> UV coordinates (from -1, to 1), where (0,0) is at the center of the screen
-float Formula(float2 Coordinates)
+// Stereographic
+float Stereographic(float2 Coordinates)
 {
 	// Convert 1/4 FOV to radians and calc tangent squared
-	float SqrTanFOVq = tan(radians(float(FOV) * 0.25));
-	SqrTanFOVq *= SqrTanFOVq;
+	float SqrTanFOVq = pow(tan(radians(FOV * 0.25)),2);
 	return (1.0 - SqrTanFOVq) / (1.0 - SqrTanFOVq * dot(Coordinates, Coordinates));
 }
+// Equisolid
+float Equisolid(float2 Coordinates)
+{
+	float rFOV = radians(FOV);
+	float R = length(Coordinates);
+	return tan(asin(sin(rFOV*0.25)*R)*2)/(tan(rFOV*0.5)*R);
+}
+// Equidistant
+float Equidistant(float2 Coordinates)
+{
+	float rFOVh = radians(FOV*0.5);
+	float R = length(Coordinates);
+	return tan(R*rFOVh)/(tan(rFOVh)*R);
+}
+
 
 // Shader pass
 float3 PerfectPerspectivePS(float4 vois : SV_Position, float2 texcoord : TexCoord) : SV_Target
@@ -137,8 +169,13 @@ float3 PerfectPerspectivePS(float4 vois : SV_Position, float2 texcoord : TexCoor
 	// Zoom in image and adjust FOV type (pass 1 of 2)
 	SphCoord *= Zooming / FovType;
 
-	// Stereographic-Gnomonic lookup, vertical distortion amount and FOV type (pass 2 of 2)
-	SphCoord *= Formula(float2(SphCoord.x, sqrt(Vertical) * SphCoord.y)) * FovType;
+	// Perspective lookup, vertical distortion amount and FOV type (pass 2 of 2)
+	switch(Projection)
+	{
+		case 0:{ SphCoord *= Stereographic(float2(SphCoord.x, sqrt(Vertical) * SphCoord.y)) * FovType; break; } // Conformal
+		case 1:{ SphCoord *= Equisolid(float2(SphCoord.x, sqrt(Vertical) * SphCoord.y)) * FovType; break; } // Equal area
+		case 2:{ SphCoord *= Equidistant(float2(SphCoord.x, sqrt(Vertical) * SphCoord.y)) * FovType; break; } // Linear scaled
+	}
 
 	// Aspect Ratio back to square
 	SphCoord.y /= AspectR;
@@ -147,7 +184,7 @@ float3 PerfectPerspectivePS(float4 vois : SV_Position, float2 texcoord : TexCoor
 	float2 PixelSize = fwidth(SphCoord);
 
 	// Outside borders check with Anti-Aliasing
-	float2 AtBorders = smoothstep( 1 - PixelSize, PixelSize + 1, abs(SphCoord) );
+	float2 AtBorders = smoothstep( 1.0 - PixelSize, 1.0 + PixelSize, abs(SphCoord) );
 
 	// Back to UV Coordinates
 	SphCoord = SphCoord * 0.5 + 0.5;
@@ -159,48 +196,48 @@ float3 PerfectPerspectivePS(float4 vois : SV_Position, float2 texcoord : TexCoor
 	Display = lerp(
 		Display, 
 		lerp(
-			Borders ? Display : tex2D(SamplerColor, texcoord).rgb, 
-			Color.rgb, 
-			Color.a
+			MirrorBorders ? Display : tex2D(SamplerColor, texcoord).rgb, 
+			BorderColor.rgb, 
+			BorderColor.a
 		), 
 		max(AtBorders.x, AtBorders.y)
 	);
 
 	// Output type choice
-	if (Debug)
+	if(DebugPreview)
 	{
 		// Calculate radial screen coordinates before and after perspective transformation
-		float4 RadialCoord = float4(texcoord, SphCoord) * 2 - 1;
+		float4 RadialCoord = float4(texcoord, SphCoord) * 2.0 - 1.0;
 		// Correct vertical aspect ratio
 		RadialCoord.yw *= AspectR;
 
 		// Define Mapping color
-		float3 UnderSmpl = float3(1, 0, 0.2); // Red
-		float3 SuperSmpl = float3(0, 1, 0.5); // Green
-		float3 NeutralSmpl = float3(0, 0.5, 1); // Blue
+		static const float3 UnderSmpl = float3(1.0, 0.0, 0.2); // Red
+		static const float3 SuperSmpl = float3(0.0, 1.0, 0.5); // Green
+		static const float3 NeutralSmpl = float3(0.0, 0.5, 1.0); // Blue
 
 		// Calculate Pixel Size difference...
-		float PixelScale = fwidth( length(RadialCoord.xy) );
+		float PixelScaleMap = fwidth( length(RadialCoord.xy) );
 		// ...and simulate Dynamic Super Resolution (DSR) scalar
-		PixelScale /= float(ResScale.y) / float(ResScale.x) * fwidth( length(RadialCoord.zw) );
-		PixelScale -= 1;
+		PixelScaleMap *= ResScale.x / (fwidth( length(RadialCoord.zw) ) * ResScale.y);
+		PixelScaleMap -= 1.0;
 
 		// Generate supersampled-undersampled color map
 		float3 ResMap = lerp(
 			SuperSmpl,
 			UnderSmpl,
-			saturate(ceil(PixelScale))
+			step(0.0, PixelScaleMap)
 		);
 
 		// Create black-white gradient mask of scale-neutral pixels
-		PixelScale = 1 - abs(PixelScale);
-		PixelScale = saturate(PixelScale * 4 - 3); // Clamp to more representative values
+		PixelScaleMap = 1.0 - abs(PixelScaleMap);
+		PixelScaleMap = saturate(PixelScaleMap * 4.0 - 3.0); // Clamp to more representative values
 
 		// Color neutral scale pixels
-		ResMap = lerp(ResMap, NeutralSmpl, PixelScale);
+		ResMap = lerp(ResMap, NeutralSmpl, PixelScaleMap);
 
 		// Blend color map with display image
-		Display = normalize(ResMap) * (0.8 * max( max(Display.r, Display.g), Display.b ) + 0.2);
+		Display = normalize(ResMap) * (0.8 * Grayscale(Display) + 0.2);
 	}
 
 	return Display;


### PR DESCRIPTION
Major update to Perfect Perspective:
• Adds new projection type for various use-cases
• Removed bug in ReShade 4.x where borders color was displayed as a vector
• Changed some tooltips
• Added Slider UI option with backward compatibility
• Various small changes

PS:
Changed line-end symbol to Windows, same as in ReShade 4.x code editor.
To see only changed code there's option "Hide white-space changes" somewhere.
![image](https://user-images.githubusercontent.com/34406163/53029527-5b54b800-3469-11e9-86f2-f2d8654088a8.png)