### PR TITLE
Improve SMAA configuration accessibility

### DIFF
--- a/Shaders/SMAA.fx
+++ b/Shaders/SMAA.fx
@@ -14,10 +14,6 @@
 
 //------------------- Preprocessor Settings -------------------
 
-#ifndef SMAA_PREDICATION
-#define SMAA_PREDICATION 0 // Disable predication by default
-#endif
-
 #if !defined(SMAA_PRESET_LOW) && !defined(SMAA_PRESET_MEDIUM) && !defined(SMAA_PRESET_HIGH) && !defined(SMAA_PRESET_ULTRA)
 #define SMAA_PRESET_CUSTOM // Do not use a quality preset by default
 #endif
@@ -26,19 +22,23 @@
 
 #include "ReShadeUI.fxh"
 
-uniform int EdgeDetectionType <
-	ui_type = "combo";
+uniform int EdgeDetectionType < __UNIFORM_COMBO_INT1
 	ui_items = "Luminance edge detection\0Color edge detection\0Depth edge detection\0";
 	ui_label = "Edge Detection Type";
 > = 1;
 
 #ifdef SMAA_PRESET_CUSTOM
-uniform float EdgeDetectionThreshold <
-	ui_type = "drag";
-	ui_min = 0.05; ui_max = 0.20; ui_step = 0.01;
+uniform float EdgeDetectionThreshold < __UNIFORM_DRAG_FLOAT1
+	ui_min = 0.05; ui_max = 0.20; ui_step = 0.001;
 	ui_tooltip = "Edge detection threshold. If SMAA misses some edges try lowering this slightly.";
 	ui_label = "Edge Detection Threshold";
-> = 0.05;
+> = 0.10;
+
+uniform float DepthEdgeDetectionThreshold < __UNIFORM_DRAG_FLOAT1
+	ui_min = 0.001; ui_max = 0.10; ui_step = 0.001;
+	ui_tooltip = "Depth Edge detection threshold. If SMAA misses some edges try lowering this slightly.";
+	ui_label = "Depth Edge Detection Threshold";
+> = 0.01;
 
 uniform int MaxSearchSteps < __UNIFORM_SLIDER_INT1
 	ui_min = 0; ui_max = 112;
@@ -58,44 +58,44 @@ uniform int CornerRounding < __UNIFORM_SLIDER_INT1
 	ui_tooltip = "Determines the percent of anti-aliasing to apply to corners.";
 > = 25;
 
-#if SMAA_PREDICATION
-uniform float PredicationThreshold <
-	ui_type = "drag";
+uniform bool PredicationEnabled < __UNIFORM_INPUT_BOOL1
+	ui_label = "Enable Predicated Thresholding";
+> = false;
+
+uniform float PredicationThreshold < __UNIFORM_DRAG_FLOAT1
 	ui_min = 0.005; ui_max = 1.00; ui_step = 0.01;
 	ui_tooltip = "Threshold to be used in the additional predication buffer.";
 	ui_label = "Predication Threshold";
 > = 0.01;
 
 uniform float PredicationScale < __UNIFORM_SLIDER_FLOAT1
-	ui_min = 1; ui_max = 5;
+	ui_min = 1; ui_max = 8;
 	ui_tooltip = "How much to scale the global threshold used for luma or color edge.";
 	ui_label = "Predication Scale";
 > = 2.0;
 
 uniform float PredicationStrength < __UNIFORM_SLIDER_FLOAT1
-	ui_min = 0; ui_max = 1;
+	ui_min = 0; ui_max = 4;
 	ui_tooltip = "How much to locally decrease the threshold.";
 	ui_label = "Predication Strength";
 > = 0.4;
 #endif
-#endif
 
-uniform int DebugOutput <
-	ui_type = "combo";
+uniform int DebugOutput < __UNIFORM_COMBO_INT1
 	ui_items = "None\0View edges\0View weights\0";
 	ui_label = "Debug Output";
 > = false;
 
 #ifdef SMAA_PRESET_CUSTOM
+	#define SMAA_PREDICATION PredicationEnabled
 	#define SMAA_THRESHOLD EdgeDetectionThreshold
+	#define SMAA_DEPTH_THRESHOLD DepthEdgeDetectionThreshold
 	#define SMAA_MAX_SEARCH_STEPS MaxSearchSteps
 	#define SMAA_MAX_SEARCH_STEPS_DIAG MaxSearchStepsDiagonal
 	#define SMAA_CORNER_ROUNDING CornerRounding
-	#if SMAA_PREDICATION
-		#define SMAA_PREDICATION_THRESHOLD PredicationThreshold
-		#define SMAA_PREDICATION_SCALE PredicationScale
-		#define SMAA_PREDICATION_STRENGTH PredicationStrength
-	#endif
+	#define SMAA_PREDICATION_THRESHOLD PredicationThreshold
+	#define SMAA_PREDICATION_SCALE PredicationScale
+	#define SMAA_PREDICATION_STRENGTH PredicationStrength
 #endif
 
 #define SMAA_RT_METRICS float4(BUFFER_RCP_WIDTH, BUFFER_RCP_HEIGHT, BUFFER_WIDTH, BUFFER_HEIGHT)
@@ -249,20 +249,18 @@ float2 SMAAEdgeDetectionWrapPS(
 	float2 texcoord : TEXCOORD0,
 	float4 offset[3] : TEXCOORD1) : SV_Target
 {
-	if (EdgeDetectionType == 0)
-		return SMAALumaEdgeDetectionPS(texcoord, offset, colorGammaSampler
-	#if SMAA_PREDICATION
-		, depthLinearSampler
-	#endif
-		);
+	if (EdgeDetectionType == 0 && SMAA_PREDICATION == true)
+		return SMAALumaEdgePredicationDetectionPS(texcoord, offset, colorGammaSampler, depthLinearSampler);
+	else if (EdgeDetectionType == 0)
+		return SMAALumaEdgeDetectionPS(texcoord, offset, colorGammaSampler);
+
 	if (EdgeDetectionType == 2)
 		return SMAADepthEdgeDetectionPS(texcoord, offset, depthLinearSampler);
 
-	return SMAAColorEdgeDetectionPS(texcoord, offset, colorGammaSampler
-	#if SMAA_PREDICATION
-		, depthLinearSampler
-	#endif
-		);
+	if (SMAA_PREDICATION)
+		return SMAAColorEdgePredicationDetectionPS(texcoord, offset, colorGammaSampler, depthLinearSampler);
+	else
+		return SMAAColorEdgeDetectionPS(texcoord, offset, colorGammaSampler);
 }
 float4 SMAABlendingWeightCalculationWrapPS(
 	float4 position : SV_Position,

--- a/Shaders/SMAA.fxh
+++ b/Shaders/SMAA.fxh
@@ -436,7 +436,7 @@
  * How much to scale the global threshold used for luma or color edge
  * detection when using predication.
  *
- * Range: [1, 5]
+ * Range: [1, 16]
  */
 #ifndef SMAA_PREDICATION_SCALE
 #define SMAA_PREDICATION_SCALE 2.0
@@ -445,7 +445,7 @@
 /**
  * How much to locally decrease the threshold.
  *
- * Range: [0, 1]
+ * Range: [0, 4]
  */
 #ifndef SMAA_PREDICATION_STRENGTH
 #define SMAA_PREDICATION_STRENGTH 0.4
@@ -689,16 +689,56 @@ void SMAANeighborhoodBlendingVS(float2 texcoord,
 float2 SMAALumaEdgeDetectionPS(float2 texcoord,
                                float4 offset[3],
                                SMAATexture2D(colorTex)
-                               #if SMAA_PREDICATION
-                               , SMAATexture2D(predicationTex)
-                               #endif
                                ) {
     // Calculate the threshold:
-    #if SMAA_PREDICATION
-    float2 threshold = SMAACalculatePredicatedThreshold(texcoord, offset, SMAATexturePass2D(predicationTex));
-    #else
-    float2 threshold = float2(SMAA_THRESHOLD, SMAA_THRESHOLD);
-    #endif
+	const float2 threshold = float2(SMAA_THRESHOLD, SMAA_THRESHOLD);
+
+    // Calculate lumas:
+    float3 weights = float3(0.2126, 0.7152, 0.0722);
+    float L = dot(SMAASamplePoint(colorTex, texcoord).rgb, weights);
+
+    float Lleft = dot(SMAASamplePoint(colorTex, offset[0].xy).rgb, weights);
+    float Ltop  = dot(SMAASamplePoint(colorTex, offset[0].zw).rgb, weights);
+
+    // We do the usual threshold:
+    float4 delta;
+    delta.xy = abs(L - float2(Lleft, Ltop));
+    float2 edges = step(threshold, delta.xy);
+
+    // Then discard if there is no edge:
+    if (dot(edges, float2(1.0, 1.0)) == 0.0)
+        discard;
+
+    // Calculate right and bottom deltas:
+    float Lright = dot(SMAASamplePoint(colorTex, offset[1].xy).rgb, weights);
+    float Lbottom  = dot(SMAASamplePoint(colorTex, offset[1].zw).rgb, weights);
+    delta.zw = abs(L - float2(Lright, Lbottom));
+
+    // Calculate the maximum delta in the direct neighborhood:
+    float2 maxDelta = max(delta.xy, delta.zw);
+
+    // Calculate left-left and top-top deltas:
+    float Lleftleft = dot(SMAASamplePoint(colorTex, offset[2].xy).rgb, weights);
+    float Ltoptop = dot(SMAASamplePoint(colorTex, offset[2].zw).rgb, weights);
+    delta.zw = abs(float2(Lleft, Ltop) - float2(Lleftleft, Ltoptop));
+
+    // Calculate the final maximum delta:
+    maxDelta = max(maxDelta.xy, delta.zw);
+    float finalDelta = max(maxDelta.x, maxDelta.y);
+
+    // Local contrast adaptation:
+    edges.xy *= step(finalDelta, SMAA_LOCAL_CONTRAST_ADAPTATION_FACTOR * delta.xy);
+
+    return edges;
+}
+
+float2 SMAALumaEdgePredicationDetectionPS(float2 texcoord,
+                               float4 offset[3],
+                               SMAATexture2D(colorTex)
+                               , SMAATexture2D(predicationTex)
+                               ) {
+    // Calculate the threshold:
+	float2 threshold = SMAACalculatePredicatedThreshold(texcoord, offset, SMAATexturePass2D(predicationTex));
 
     // Calculate lumas:
     float3 weights = float3(0.2126, 0.7152, 0.0722);
@@ -748,16 +788,67 @@ float2 SMAALumaEdgeDetectionPS(float2 texcoord,
 float2 SMAAColorEdgeDetectionPS(float2 texcoord,
                                 float4 offset[3],
                                 SMAATexture2D(colorTex)
-                                #if SMAA_PREDICATION
-                                , SMAATexture2D(predicationTex)
-                                #endif
                                 ) {
     // Calculate the threshold:
-    #if SMAA_PREDICATION
-    float2 threshold = SMAACalculatePredicatedThreshold(texcoord, offset, predicationTex);
-    #else
     float2 threshold = float2(SMAA_THRESHOLD, SMAA_THRESHOLD);
-    #endif
+
+    // Calculate color deltas:
+    float4 delta;
+    float3 C = SMAASamplePoint(colorTex, texcoord).rgb;
+
+    float3 Cleft = SMAASamplePoint(colorTex, offset[0].xy).rgb;
+    float3 t = abs(C - Cleft);
+    delta.x = max(max(t.r, t.g), t.b);
+
+    float3 Ctop  = SMAASamplePoint(colorTex, offset[0].zw).rgb;
+    t = abs(C - Ctop);
+    delta.y = max(max(t.r, t.g), t.b);
+
+    // We do the usual threshold:
+    float2 edges = step(threshold, delta.xy);
+
+    // Then discard if there is no edge:
+    if (dot(edges, float2(1.0, 1.0)) == 0.0)
+        discard;
+
+    // Calculate right and bottom deltas:
+    float3 Cright = SMAASamplePoint(colorTex, offset[1].xy).rgb;
+    t = abs(C - Cright);
+    delta.z = max(max(t.r, t.g), t.b);
+
+    float3 Cbottom  = SMAASamplePoint(colorTex, offset[1].zw).rgb;
+    t = abs(C - Cbottom);
+    delta.w = max(max(t.r, t.g), t.b);
+
+    // Calculate the maximum delta in the direct neighborhood:
+    float2 maxDelta = max(delta.xy, delta.zw);
+
+    // Calculate left-left and top-top deltas:
+    float3 Cleftleft  = SMAASamplePoint(colorTex, offset[2].xy).rgb;
+    t = abs(Cleft - Cleftleft);
+    delta.z = max(max(t.r, t.g), t.b);
+
+    float3 Ctoptop = SMAASamplePoint(colorTex, offset[2].zw).rgb;
+    t = abs(Ctop - Ctoptop);
+    delta.w = max(max(t.r, t.g), t.b);
+
+    // Calculate the final maximum delta:
+    maxDelta = max(maxDelta.xy, delta.zw);
+    float finalDelta = max(maxDelta.x, maxDelta.y);
+
+    // Local contrast adaptation:
+    edges.xy *= step(finalDelta, SMAA_LOCAL_CONTRAST_ADAPTATION_FACTOR * delta.xy);
+
+    return edges;
+}
+
+float2 SMAAColorEdgePredicationDetectionPS(float2 texcoord,
+                                float4 offset[3],
+                                SMAATexture2D(colorTex)
+                                , SMAATexture2D(predicationTex)
+                                ) {
+    // Calculate the threshold:
+    float2 threshold = SMAACalculatePredicatedThreshold(texcoord, offset, predicationTex);
 
     // Calculate color deltas:
     float4 delta;

--- a/Shaders/SMAA.fxh
+++ b/Shaders/SMAA.fxh
@@ -691,7 +691,7 @@ float2 SMAALumaEdgeDetectionPS(float2 texcoord,
                                SMAATexture2D(colorTex)
                                ) {
     // Calculate the threshold:
-	const float2 threshold = float2(SMAA_THRESHOLD, SMAA_THRESHOLD);
+    float2 threshold = float2(SMAA_THRESHOLD, SMAA_THRESHOLD);
 
     // Calculate lumas:
     float3 weights = float3(0.2126, 0.7152, 0.0722);


### PR DESCRIPTION
DepthEdgeDetectionThreshold and Predication as a whole were gated behind preprocessor definitions. This had the end result of Edge detection mode being non-configurable from the UI, and the latter being completely unknown or forgotten to even experienced shader developers.