### PR TITLE
Reshade.fxh modifications to allow for extra tweaks to depth buffer position and scale (For Emulators)

### DIFF
--- a/Shaders/ReShade.fxh
+++ b/Shaders/ReShade.fxh
@@ -16,6 +16,29 @@
 #ifndef RESHADE_DEPTH_LINEARIZATION_FAR_PLANE
 	#define RESHADE_DEPTH_LINEARIZATION_FAR_PLANE 1000.0
 #endif
+// Reserved for Emulators with Weak Depth Buffers
+// Keep at 1 for Stock Behaviour
+#ifndef RESHADE_DEPTH_MULTIPLIER
+	#define RESHADE_DEPTH_MULTIPLIER 1
+#endif
+// Depth Scale Factors Per Axis.
+//  Keep at 1 for Stock Behaviour.
+// Below 1 Expands and Above 1 Contracts On Relevant Axis.
+#ifndef RESHADE_DEPTH_INPUT_X_SCALE
+	#define RESHADE_DEPTH_INPUT_X_SCALE 1
+#endif
+#ifndef RESHADE_DEPTH_INPUT_Y_SCALE
+	#define RESHADE_DEPTH_INPUT_Y_SCALE 1
+#endif
+// Depth Buffer Location Offset.
+// Keep at 0 for Stock Behaviour.
+// Recommended to adjust in increments/decrements of anything between 0.005 and 0.1.
+#ifndef RESHADE_DEPTH_INPUT_X_OFFSET_SCALE
+	#define RESHADE_DEPTH_INPUT_X_OFFSET_SCALE 0
+#endif
+#ifndef RESHADE_DEPTH_INPUT_Y_OFFSET_SCALE
+	#define RESHADE_DEPTH_INPUT_Y_OFFSET_SCALE 0
+#endif
 
 namespace ReShade
 {
@@ -46,7 +69,13 @@ namespace ReShade
 #if RESHADE_DEPTH_INPUT_IS_UPSIDE_DOWN
 		texcoord.y = 1.0 - texcoord.y;
 #endif
-		float depth = tex2Dlod(DepthBuffer, float4(texcoord, 0, 0)).x;
+		// Apply the Depth Buffer Scale
+    	texcoord.y *= RESHADE_DEPTH_INPUT_Y_SCALE;
+		texcoord.x *= RESHADE_DEPTH_INPUT_X_SCALE;
+		// Apply Depth Buffer Location Offset
+    	texcoord.y -= RESHADE_DEPTH_INPUT_Y_OFFSET_SCALE;
+		texcoord.x -= RESHADE_DEPTH_INPUT_X_OFFSET_SCALE;
+		float depth = tex2Dlod(DepthBuffer, float4(texcoord, 0, 0)).x * RESHADE_DEPTH_MULTIPLIER;
 
 #if RESHADE_DEPTH_INPUT_IS_LOGARITHMIC
 		const float C = 0.01;

--- a/Shaders/ReShade.fxh
+++ b/Shaders/ReShade.fxh
@@ -22,7 +22,7 @@
 	#define RESHADE_DEPTH_MULTIPLIER 1
 #endif
 // Depth Scale Factors Per Axis.
-//  Keep at 1 for Stock Behaviour.
+// Keep at 1 for Stock Behaviour.
 // Below 1 Expands and Above 1 Contracts On Relevant Axis.
 #ifndef RESHADE_DEPTH_INPUT_X_SCALE
 	#define RESHADE_DEPTH_INPUT_X_SCALE 1
@@ -69,13 +69,25 @@ namespace ReShade
 #if RESHADE_DEPTH_INPUT_IS_UPSIDE_DOWN
 		texcoord.y = 1.0 - texcoord.y;
 #endif
-		// Apply the Depth Buffer Scale
+		// Apply the Depth Buffer Scale if modified
+#if RESHADE_DEPTH_INPUT_Y_SCALE != 0
     	texcoord.y *= RESHADE_DEPTH_INPUT_Y_SCALE;
+#endif
+#if RESHADE_DEPTH_INPUT_X_SCALE != 0
 		texcoord.x *= RESHADE_DEPTH_INPUT_X_SCALE;
-		// Apply Depth Buffer Location Offset
+#endif
+		// Apply Depth Buffer Location Offset if modified
+#if RESHADE_DEPTH_INPUT_Y_OFFSET_SCALE != 1
     	texcoord.y -= RESHADE_DEPTH_INPUT_Y_OFFSET_SCALE;
+#endif
+#if RESHADE_DEPTH_INPUT_X_OFFSET_SCALE != 1
 		texcoord.x -= RESHADE_DEPTH_INPUT_X_OFFSET_SCALE;
+#endif
+#if RESHADE_DEPTH_MULTIPLIER != 1
 		float depth = tex2Dlod(DepthBuffer, float4(texcoord, 0, 0)).x * RESHADE_DEPTH_MULTIPLIER;
+#else
+		float depth = tex2Dlod(DepthBuffer, float4(texcoord, 0, 0)).x;
+#endif
 
 #if RESHADE_DEPTH_INPUT_IS_LOGARITHMIC
 		const float C = 0.01;
@@ -94,7 +106,15 @@ namespace ReShade
 // Vertex shader generating a triangle covering the entire screen
 void PostProcessVS(in uint id : SV_VertexID, out float4 position : SV_Position, out float2 texcoord : TEXCOORD)
 {
-	texcoord.x = (id == 2) ? 2.0 : 0.0;
-	texcoord.y = (id == 1) ? 2.0 : 0.0;
+	if (id == 2)
+		texcoord.x = 2.0;
+	else
+		texcoord.x = 0.0;
+
+	if (id == 1)
+		texcoord.y = 2.0;
+	else
+		texcoord.y = 0.0;
+
 	position = float4(texcoord * float2(2.0, -2.0) + float2(-1.0, 1.0), 0.0, 1.0);
 }


### PR DESCRIPTION
Modification made after suggestion by crosire in reference to an issue with PCSX2. Then expanded upon to allow for DB scaling on the X axis and for positioning on the x/y axis with an offset.

Also includes a preprocessor to enable a reshade.fxh tweak suggested by boulotaur over on the reshade forums to help games/emulators with a weak depth buffer to be used without manually modifying reshade.fxh each time (https://reshade.me/forum/general-discussion/5391-release-pcsx2-with-depth-buffer-access).

In checking for feedback on discord, Marot/Mortalitas modified my already modified file and optimized my preprocessor additions and other elements of the file and then gave permission for the optimized file to be uploaded under this pull.