### PR TITLE
Prod80 B&W shader addition

### DIFF
--- a/Shaders/PD80 Black & White.fx
+++ b/Shaders/PD80 Black & White.fx
@@ -1,0 +1,767 @@
+/* 
+Black and White shader by prod80 for ReShade
+Version 1.2
+*/
+
+/* Additional credits:
+ *
+ * Deband shader by haasn
+ * https://github.com/haasn/gentoo-conf/blob/xor/home/nand/.mpv/shaders/deband-pre.glsl
+ *
+ * Copyright (c) 2015 Niklas Haas
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Modified and optimized for ReShade by JPulowski
+ * https://reshade.me/forum/shader-presentation/768-deband
+ *
+ * Do not distribute without giving credit to the original author(s).
+ */
+
+/*
+ * Additional credits:
+ *
+ * Noise/Grain code adopted, modified, and adjusted from Martins H.
+ * This work is licensed under a Creative Commons Attribution 3.0 Unported License.
+ * http://devlog-martinsh.blogspot.com/2013/05/image-imperfections-and-film-grain-post.html
+ */
+
+#include "ReShade.fxh"
+#include "ReShadeUI.fxh"
+
+namespace pd80_blackandwhite
+{
+
+    //// UI ELEMENTS ////////////////////////////////////////////////////////////////
+    // Level Controls
+    uniform float3 inWhite <
+        ui_type = "color";
+        ui_label = "IN White Point Adjustment";
+        ui_category = "Black & White (general)";
+        > = float3(1.0, 1.0, 1.0);
+    uniform float3 inBlack <
+        ui_type = "color";
+        ui_label = "IN Black Point Adjustment";
+        ui_category = "Black & White (general)";
+        > = float3(0.0, 0.0, 0.0);
+    uniform float3 White <
+        ui_type = "color";
+        ui_label = "OUT White Point Adjustment";
+        ui_category = "Black & White (general)";
+        > = float3(0.922, 0.922, 0.922);
+    uniform float3 Black <
+        ui_type = "color";
+        ui_label = "OUT Black Point Adjustment";
+        ui_category = "Black & White (general)";
+        > = float3(0.078, 0.078, 0.078);
+    uniform float Gamma <
+        ui_type = "slider";
+        ui_label = "Gamma Adjustment";
+        ui_category = "Black & White (general)";
+        ui_min = 0.0f;
+        ui_max = 5.0f;
+        > = 1.3;
+    // B&W Techniques
+    uniform float3 luminosity <
+        ui_type = "color";
+        ui_label = "Select Color to Convert B&W";
+        ui_category = "Black & White Techniques";
+        > = float3(0.6, 1.0, 0.4);
+    // Gaussian Blur
+    uniform float BlurSigma <
+        ui_type = "slider";
+        ui_label = "Blur Width";
+        ui_category = "Black & White Blend Mode (Blur)";
+        ui_min = 0.001f;
+        ui_max = 30.0f;
+        > = 4.0;
+    uniform int BlendModeB < __UNIFORM_COMBO_INT1
+        ui_label = "Blend Mode";
+        ui_category = "Black & White Blend Mode (Blur)";
+        ui_items = "Normal\0Darken\0Multiply\0Linearburn\0Colorburn\0Lighten\0Screen\0Colordodge\0Lineardodge\0Overlay\0Softlight\0Vividlight\0Linearlight\0Pinlight\0";
+        > = 10;
+    uniform float opacityB <
+        ui_type = "slider";
+        ui_label = "Opacity";
+        ui_category = "Black & White Blend Mode (Blur)";
+        ui_min = 0.0f;
+        ui_max = 1.0f;
+        > = 0.333;
+    uniform bool use_unblur <
+        ui_label = "Use Unblurred Image as Blend";
+        ui_category = "Black & White Blend Mode (Gradient or Unblur)";
+        > = false;
+    uniform bool use_gradient <
+        ui_label = "Use Gradient Image as Blend";
+        ui_category = "Black & White Blend Mode (Gradient or Unblur)";
+        > = false;
+    uniform float3 LightColor <
+        ui_type = "color";
+        ui_label = "Highlight Color Gradient";
+        ui_category = "Black & White Blend Mode (Gradient or Unblur)";
+        > = float3(1.0, 0.5, 0.0);
+    uniform float3 DarkColor <
+        ui_type = "color";
+        ui_label = "Shadow Color Gradient";
+        ui_category = "Black & White Blend Mode (Gradient or Unblur)";
+        > = float3(0.0, 0.5, 1.0);
+    uniform int BlendMode < __UNIFORM_COMBO_INT1
+        ui_label = "Blend Mode";
+        ui_category = "Black & White Blend Mode (Gradient or Unblur)";
+        ui_items = "Normal\0Darken\0Multiply\0Linearburn\0Colorburn\0Lighten\0Screen\0Colordodge\0Lineardodge\0Overlay\0Softlight\0Vividlight\0Linearlight\0Pinlight\0";
+        > = 5;
+    uniform float opacity <
+        ui_type = "slider";
+        ui_label = "Opacity";
+        ui_category = "Black & White Blend Mode (Gradient or Unblur)";
+        ui_min = 0.0f;
+        ui_max = 1.0f;
+        > = 0.0;
+    uniform bool blendOrig <
+        ui_label = "Blend Black & White with Original";
+        ui_category = "Black & White Blend Mode (Blend Original)";
+        > = false;
+    uniform bool flipColorBlend <
+        ui_label = "Flip Blend Layers";
+        ui_category = "Black & White Blend Mode (Blend Original)";
+        > = false;
+    uniform int BlendModeO < __UNIFORM_COMBO_INT1
+        ui_label = "Blend Mode";
+        ui_category = "Black & White Blend Mode (Blend Original)";
+        ui_items = "Normal\0Darken\0Multiply\0Linearburn\0Colorburn\0Lighten\0Screen\0Colordodge\0Lineardodge\0Overlay\0Softlight\0Vividlight\0Linearlight\0Pinlight\0";
+        > = 0;
+    uniform float opacityO <
+        ui_type = "slider";
+        ui_label = "Opacity";
+        ui_category = "Black & White Blend Mode (Blend Original)";
+        ui_min = 0.0f;
+        ui_max = 1.0f;
+        > = 0.0;
+    // Final adjustments
+    uniform float contrast <
+        ui_type = "slider";
+        ui_label = "Contrast";
+        ui_category = "Black & White Final Adjustments";
+        ui_min = -1.0f;
+        ui_max = 1.0f;
+        > = 0.0;
+    uniform float brightness <
+        ui_type = "slider";
+        ui_label = "Brightness";
+        ui_category = "Black & White Final Adjustments";
+        ui_min = -1.0f;
+        ui_max = 1.0f;
+        > = 0.0;
+    uniform bool use_ca <
+        ui_label = "Enable Chromatic Aberration";
+        ui_category = "Chromatic Aberration";
+        > = true;
+    uniform bool use_ca_edges <
+        ui_label = "Chromatic Aberration Only Edges.\nUse Rotation = 225 for best effect.";
+        ui_category = "Chromatic Aberration";
+        > = true;
+    uniform int degrees <
+        ui_type = "slider";
+        ui_label = "Chromatic Aberration Rotation";
+        ui_category = "Chromatic Aberration";
+        ui_min = 0;
+        ui_max = 360;
+        ui_step = 1;
+        > = 225;
+    uniform float CA <
+        ui_type = "slider";
+        ui_label = "Chromatic Aberration Width";
+        ui_category = "Chromatic Aberration";
+        ui_min = 0.0f;
+        ui_max = 100.0f;
+        > = 5.0;
+    uniform float CA_strength <
+        ui_type = "slider";
+        ui_label = "Chromatic Aberration Strength";
+        ui_category = "Chromatic Aberration";
+        ui_min = 0.0f;
+        ui_max = 1.0f;
+        > = 0.5;
+    uniform bool use_grain <
+        ui_label = "Enable Film Grain";
+        ui_category = "Film Grain (perlin)";
+        > = false;
+    uniform float grainColor <
+        ui_type = "slider";
+        ui_label = "Grain Color Amount";
+        ui_category = "Film Grain (perlin)";
+        ui_min = 0.0f;
+        ui_max = 1.0f;
+        > = 0.0;
+    uniform float grainAmount <
+        ui_type = "slider";
+        ui_label = "Grain Amount";
+        ui_category = "Film Grain (perlin)";
+        ui_min = 0.0f;
+        ui_max = 1.0f;
+        > = 0.05;
+    uniform float grainIntensity <
+        ui_type = "slider";
+        ui_label = "Grain Intensity Global";
+        ui_category = "Film Grain (perlin)";
+        ui_min = 0.0f;
+        ui_max = 1.0f;
+        > = 0.2;
+    uniform float grainIntHigh <
+        ui_type = "slider";
+        ui_label = "Grain Intensity Highlights";
+        ui_category = "Film Grain (perlin)";
+        ui_min = 0.0f;
+        ui_max = 1.0f;
+        > = 0.7;
+    uniform float grainIntLow <
+        ui_type = "slider";
+        ui_label = "Grain Intensity Shadows";
+        ui_category = "Film Grain (perlin)";
+        ui_min = 0.0f;
+        ui_max = 1.0f;
+        > = 1.0;
+    //// TEXTURES ///////////////////////////////////////////////////////////////////
+    texture texColorBuffer : COLOR;
+    texture texColorNew { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; }; 
+    texture texBlurH { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; }; 
+    texture texBlur { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; };
+    texture texBlurDeband { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; };
+    texture texBlended { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; };
+    texture texAfterFX1 { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; };
+    //// SAMPLERS ///////////////////////////////////////////////////////////////////
+    sampler samplerColor { Texture = texColorBuffer; };
+    sampler samplerColorNew { Texture = texColorNew; };
+    sampler samplerBlurH { Texture = texBlurH; };
+    sampler samplerBlur { Texture = texBlur; };
+    sampler samplerBlurDeband { Texture = texBlurDeband; };
+    sampler samplerBlended { Texture = texBlended; };
+    sampler samplerAfterFX1 { Texture = texAfterFX1; };
+    //// DEFINES ////////////////////////////////////////////////////////////////////
+    #define Pi          3.141592f
+    #define Loops       150
+    #define Quality     0.985f
+    #define px          1.0f / BUFFER_WIDTH
+    #define py          1.0f / BUFFER_HEIGHT
+    //// BUFFERS ////////////////////////////////////////////////////////////////////
+    // Not supported in ReShade (?)
+
+    //// FUNCTIONS //////////////////////////////////////////////////////////////////
+    uniform int drandom < source = "random"; min = 0; max = 32767; >;
+    uniform float Timer < source = "timer"; >;
+    #define timer float( Timer % 1000.0 )
+    //#define timer float( 1.0 )
+
+    void analyze_pixels(float3 ori, sampler2D tex, float2 texcoord, float2 _range, float2 dir, out float3 ref_avg, out float3 ref_avg_diff, out float3 ref_max_diff, out float3 ref_mid_diff1, out float3 ref_mid_diff2)
+    {
+        // South-east
+        float3 ref        = tex2Dlod( tex, float4( texcoord + _range * dir, 0.0f, 0.0f )).rgb;
+        float3 diff       = abs( ori - ref );
+        ref_max_diff      = diff;
+        ref_avg           = ref;
+        ref_mid_diff1     = ref;
+        // North-west
+        ref               = tex2Dlod( tex, float4( texcoord + _range * -dir, 0.0f, 0.0f )).rgb;
+        diff              = abs( ori - ref );
+        ref_max_diff      = max( ref_max_diff, diff );
+        ref_avg           += ref;
+        ref_mid_diff1     = abs((( ref_mid_diff1 + ref ) * 0.5f ) - ori );
+        // North-east
+        ref               = tex2Dlod( tex, float4( texcoord + _range * float2( -dir.y, dir.x ), 0.0f, 0.0f )).rgb;
+        diff              = abs( ori - ref );
+        ref_max_diff      = max( ref_max_diff, diff );
+        ref_avg           += ref;
+        ref_mid_diff2     = ref;
+        // South-west
+        ref               = tex2Dlod( tex, float4( texcoord + _range * float2( dir.y, -dir.x ), 0.0f, 0.0f )).rgb;
+        diff              = abs( ori - ref );
+        ref_max_diff      = max( ref_max_diff, diff );
+        ref_avg           += ref;
+        ref_mid_diff2     = abs((( ref_mid_diff2 + ref ) * 0.5f ) - ori );
+        // Normalize avg
+        ref_avg           *= 0.25f;
+        ref_avg_diff      = abs( ori - ref_avg );
+    }
+
+    float permute( in float x )
+    {
+        return ((34.0f * x + 1.0f) * x) % 289.0f;
+    }
+
+    float rand( in float x )
+    {
+        return frac(x / 41.0f);
+    }
+
+    float3 darken(float3 c, float3 b) 		{ return min(b, c);}
+    float3 multiply(float3 c, float3 b) 	{ return c*b;}
+    float3 linearburn(float3 c, float3 b) 	{ return max(c+b-1.0f, 0.0f);}
+    float3 colorburn(float3 c, float3 b) 	{ return b==0.0f ? b:max((1.0f-((1.0f-c)/b)), 0.0f);}
+    float3 lighten(float3 c, float3 b) 		{ return max(b, c);}
+    float3 screen(float3 c, float3 b) 		{ return 1.0f-(1.0f-c)*(1.0f-b);}
+    float3 colordodge(float3 c, float3 b) 	{ return b==1.0f ? b:min(c/(1.0f-b), 1.0f);}
+    float3 lineardodge(float3 c, float3 b) 	{ return min(c+b, 1.0f);}
+    float3 overlay(float3 c, float3 b) 		{ return c<0.5f ? 2.0f*c*b:(1.0f-2.0f*(1.0f-c)*(1.0f-b));}
+    float3 softlight(float3 c, float3 b) 	{ return b<0.5f ? (2.0f*c*b+c*c*(1.0f-2.0f*b)):(sqrt(c)*(2.0f*b-1.0f)+2.0f*c*(1.0f-b));}
+    float3 vividlight(float3 c, float3 b) 	{ return b<0.5f ? colorburn(c, (2.0f*b)):colordodge(c, (2.0f*(b-0.5f)));}
+    float3 linearlight(float3 c, float3 b) 	{ return b<0.5f ? linearburn(c, (2.0f*b)):lineardodge(c, (2.0f*(b-0.5f)));}
+    float3 pinlight(float3 c, float3 b) 	{ return b<0.5f ? darken(c, (2.0f*b)):lighten(c, (2.0f*(b-0.5f)));}
+
+    float4 rnm( float2 tc ) 
+    {
+        float noise       = sin( dot( tc + float2( timer, timer ),float2( 12.9898, 78.233 ))) * 43758.5453;
+        float noiseR      = frac( noise ) * 2.0 - 1.0;
+        float noiseG      = frac( noise * 1.2154 ) * 2.0 - 1.0; 
+        float noiseB      = frac( noise * 1.3453 ) * 2.0 - 1.0;
+        float noiseA      = frac( noise * 1.3647 ) * 2.0 - 1.0;
+        return float4( noiseR, noiseG, noiseB, noiseA );
+    }
+
+    float fade( float t )
+    {
+        return t * t * t * ( t * ( t * 6.0 - 15.0 ) + 10.0 );
+    }
+
+    float pnoise3D( float3 p, float2 pos )
+    {   
+        float3 pf         = frac( p );
+        // Noise contributions from (x=0, y=0), z=0 and z=1
+        float perm00      = rnm( pos.xy ).a;
+        float3 grad000    = rnm( float2( perm00, pos.y )).rgb * 4.0 - 1.0;
+        float n000        = dot( grad000, pf );
+        float3 grad001    = rnm( float2( perm00, pos.y + py )).rgb * 4.0 - 1.0;
+        float n001        = dot( grad001, pf - float3( 0.0, 0.0, 1.0 ));
+        // Noise contributions from (x=0, y=1), z=0 and z=1
+        float perm01      = rnm( pos.xy + float2( 0.0, py )).a ;
+        float3  grad010   = rnm( float2( perm01, pos.y )).rgb * 4.0 - 1.0;
+        float n010        = dot( grad010, pf - float3( 0.0, 1.0, 0.0 ));
+        float3  grad011   = rnm( float2(perm01, pos.y + py)).rgb * 4.0 - 1.0;
+        float n011        = dot( grad011, pf - float3( 0.0, 1.0, 1.0 ));
+        // Noise contributions from (x=1, y=0), z=0 and z=1
+        float perm10      = rnm( pos.xy + float2( BUFFER_RCP_WIDTH, 0.0 )).a ;
+        float3  grad100   = rnm( float2( perm10, pos.y )).rgb * 4.0 - 1.0;
+        float n100        = dot( grad100, pf - float3( 1.0, 0.0, 0.0 ));
+        float3  grad101   = rnm( float2( perm10, pos.y + py )).rgb * 4.0 - 1.0;
+        float n101        = dot( grad101, pf - float3( 1.0, 0.0, 1.0 ));
+        // Noise contributions from (x=1, y=1), z=0 and z=1
+        float perm11      = rnm( pos.xy + float2( px, py )).a ;
+        float3  grad110   = rnm( float2( perm11, pos.y )).rgb * 4.0 - 1.0;
+        float n110        = dot( grad110, pf - float3( 1.0, 1.0, 0.0 ));
+        float3  grad111   = rnm( float2( perm11, pos.y + py )).rgb * 4.0 - 1.0;
+        float n111        = dot( grad111, pf - float3( 1.0, 1.0, 1.0 ));
+        // Blend contributions along x
+        float4 n_x        = lerp( float4( n000, n001, n010, n011 ), float4( n100, n101, n110, n111 ), fade( pf.x ));
+        // Blend contributions along y
+        float2 n_xy       = lerp( n_x.xy, n_x.zw, fade( pf.y ));
+        // Blend contributions along z
+        float n_xyz       = lerp( n_xy.x, n_xy.y, fade( pf.z ));
+        // We're done, return the final noise value
+        return n_xyz;
+    }
+
+    //2d coordinate orientation thing
+    float2 coordRot( float2 tc, float angle )
+    {
+        float aspect      = BUFFER_WIDTH / BUFFER_HEIGHT;
+        float rotX        = (( tc.x * 2.0 - 1.0 ) * aspect * cos( angle )) - (( tc.y * 2.0 - 1.0 ) * sin( angle ));
+        float rotY        = (( tc.y * 2.0 - 1.0 ) * cos( angle )) + (( tc.x * 2.0 - 1.0 ) * aspect * sin( angle ));
+        rotX              = (( rotX / aspect ) * 0.5 + 0.5 );
+        rotY              = rotY * 0.5 + 0.5;
+        return float2( rotX, rotY );
+    }
+
+    //// COMPUTE SHADERS ////////////////////////////////////////////////////////////
+    // Not supported in ReShade (?)
+
+    //// PIXEL SHADERS //////////////////////////////////////////////////////////////
+    float4 PS_BlackandWhite(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+    {
+        float4 color      = tex2D( samplerColor, texcoord );
+        // Levels
+        color.xyz         = max( color.xyz - inBlack.xyz, 0.0f )/max( inWhite.xyz - inBlack.xyz, 0.000001f );
+        color.xyz         = pow( color.xyz, Gamma );
+        color.xyz         = color.xyz * max( White.xyz - Black.xyz, 0.000001f ) + Black.xyz;
+        color.xyz         = max( color.xyz, 0.0f );
+        // B & W conversion options
+        // Technique 1: Selection of any RGB to create the B&W image
+        float gsMult      = dot( luminosity.xyz, 1.0f );
+        float3 greyscale  = luminosity.xyz / gsMult;
+        color.xyz         = dot( color.xyz, greyscale.xyz );
+        // Technique 2: Use multiplification of R G B or Luma channel to create B&W image
+        // TODO
+
+        return float4( color.xyz, 1.0f ); // Writes to texColorNew
+    }
+    
+    float4 PS_GaussianH(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+    {
+        float4 color      = tex2D( samplerColorNew, texcoord );
+        float SigmaSum    = 0.0f;
+        float pxlOffset   = 1.0f;
+        float3 Sigma;
+        Sigma.x           = 1.0f / ( sqrt( 2.0f * Pi ) * BlurSigma );
+        Sigma.y           = exp( -0.5f / ( BlurSigma * BlurSigma ));
+        Sigma.z           = Sigma.y * Sigma.y;
+        color.xyz         *= Sigma.x;
+        SigmaSum          += Sigma.x;
+        Sigma.xy          *= Sigma.yz;
+        for( int i = 0; i < Loops && SigmaSum <= Quality; ++i )
+        {
+            color         += tex2D( samplerColorNew, texcoord.xy + float2( pxlOffset*px, 0.0f )) * Sigma.x;
+            color         += tex2D( samplerColorNew, texcoord.xy - float2( pxlOffset*px, 0.0f )) * Sigma.x;
+            SigmaSum      += ( 2.0f * Sigma.x );
+            pxlOffset     += 1.0f;
+            Sigma.xy      *= Sigma.yz;
+        }
+        color.xyz         /= SigmaSum;
+        return float4( color.xyz, 1.0f ); // Writes to texBlurH
+    }
+    
+    float4 PS_GaussianV(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+    {
+        float4 color      = tex2D( samplerBlurH, texcoord );
+        float SigmaSum    = 0.0f;
+        float pxlOffset   = 1.0f;
+        float3 Sigma;
+        Sigma.x           = 1.0f / ( sqrt( 2.0f * Pi ) * BlurSigma );
+        Sigma.y           = exp( -0.5f / ( BlurSigma * BlurSigma ));
+        Sigma.z           = Sigma.y * Sigma.y;
+        color.xyz         *= Sigma.x;
+        SigmaSum          += Sigma.x;
+        Sigma.xy          *= Sigma.yz;
+        for( int i = 0; i < Loops && SigmaSum < Quality; ++i )
+        {
+            color         += tex2D( samplerBlurH, texcoord.xy + float2( 0.0f, pxlOffset*py )) * Sigma.x;
+            color         += tex2D( samplerBlurH, texcoord.xy - float2( 0.0f, pxlOffset*py )) * Sigma.x;
+            SigmaSum      += ( 2.0f * Sigma.x );
+            pxlOffset     += 1.0f;
+            Sigma.xy      *= Sigma.yz;
+        }
+        color.xyz         /= SigmaSum;
+        return float4( color.xyz, 1.0f ); // Writes to texBlur
+    }
+
+    float4 PS_BloomDeband(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+    {
+        float4 color      = tex2D( samplerBlur, texcoord );
+        float avgdiff     = 3.4f / 255.0f;
+        float maxdiff     = 6.8f / 255.0f;
+        float middiff     = 3.3f / 255.0f;
+        float h           = permute( permute( permute( texcoord.x ) + texcoord.y ) + drandom / 32767.0f );
+        float3 ref_avg;
+        float3 ref_avg_diff;
+        float3 ref_max_diff;
+        float3 ref_mid_diff1;
+        float3 ref_mid_diff2;
+        float3 ori        = color.xyz;
+        float3 res;
+        float dir         = rand( permute( h )) * 6.2831853f;
+        float2 o          = float2( cos( dir ), sin( dir ));
+        for ( int i = 1; i <= 4; ++i )
+        {
+            float dist    = rand(h) * 24.0f * i;
+            float2 pt     = dist * ReShade::PixelSize;
+            analyze_pixels(ori, samplerBlur, texcoord, pt, o,
+                            ref_avg,
+                            ref_avg_diff,
+                            ref_max_diff,
+                            ref_mid_diff1,
+                            ref_mid_diff2);
+            float3 ref_avg_diff_threshold = avgdiff * i;
+            float3 ref_max_diff_threshold = maxdiff * i;
+            float3 ref_mid_diff_threshold = middiff * i;
+            float3 factor = pow(saturate(3.0 * (1.0 - ref_avg_diff  / ref_avg_diff_threshold)) *
+                            saturate(3.0 * (1.0 - ref_max_diff  / ref_max_diff_threshold)) *
+                            saturate(3.0 * (1.0 - ref_mid_diff1 / ref_mid_diff_threshold)) *
+                            saturate(3.0 * (1.0 - ref_mid_diff2 / ref_mid_diff_threshold)), 0.1);
+            res           = lerp(ori, ref_avg, factor);
+            h             = permute(h);
+        }
+        const float dither_bit  = 8.0f;
+        float grid_position     = frac(dot(texcoord, (ReShade::ScreenSize * float2(1.0 / 16.0, 10.0 / 36.0)) + 0.25));
+        float dither_shift      = 0.25 * (1.0 / (pow(2, dither_bit) - 1.0));
+        float3 dither_shift_RGB = float3(dither_shift, -dither_shift, dither_shift);
+        dither_shift_RGB        = lerp(2.0 * dither_shift_RGB, -2.0 * dither_shift_RGB, grid_position); //shift acording to grid position.
+        res                     += dither_shift_RGB;
+        color.xyz               = res.xyz;
+        return float4( color.xyz, 1.0f ); // Writes to texBlurDeband
+    }
+
+    float4 PS_BlendImgBlur(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+    {
+        float4 color      = tex2D( samplerColorNew, texcoord );
+        float4 blur       = tex2D( samplerBlurDeband, texcoord );
+        float4 orig       = tex2D( samplerColor, texcoord );
+        float3 blend      = 0.0f;
+        // Blending options (blur)
+        if( BlendModeB == 0 ) {
+            blend.xyz     = blur.xyz;
+        }
+        if( BlendModeB == 1 ) {
+            blend.xyz     = darken( color.xyz, blur.xyz);
+        }
+        if( BlendModeB == 2 ) {
+            blend.xyz     = multiply( color.xyz, blur.xyz);
+        }
+        if( BlendModeB == 3 ) {
+            blend.xyz     = linearburn( color.xyz, blur.xyz);
+        }
+        if( BlendModeB == 4 ) {
+            blend.xyz     = colorburn( color.xyz, blur.xyz);
+        }
+        if( BlendModeB == 5 ) {
+            blend.xyz     = lighten( color.xyz, blur.xyz);
+        }
+        if( BlendModeB == 6 ) {
+            blend.xyz     = screen( color.xyz, blur.xyz);
+        }
+        if( BlendModeB == 7 ) {
+            blend.xyz     = colordodge( color.xyz, blur.xyz);
+        }
+        if( BlendModeB == 8 ) {
+            blend.xyz     = lineardodge( color.xyz, blur.xyz);
+        }
+        if( BlendModeB == 9 ) {
+            blend.xyz     = overlay( color.xyz, blur.xyz);
+        }
+        if( BlendModeB == 10 ) {
+            blend.xyz     = softlight( color.xyz, blur.xyz);
+        }
+        if( BlendModeB == 11 ) {
+            blend.xyz     = vividlight( color.xyz, blur.xyz);
+        }
+        if( BlendModeB == 12 ) {
+            blend.xyz     = linearlight( color.xyz, blur.xyz);
+        }
+        if( BlendModeB == 13 ) {
+            blend.xyz     = pinlight( color.xyz, blur.xyz);
+        }
+        color.xyz         = lerp( color.xyz, blend.xyz, opacityB );
+        // For color grading options (non blur or gradient)
+        if( use_unblur ) {
+            blur.xyz      = color.xyz;
+        }
+        if( use_gradient ) {
+            float3 darkC  = DarkColor.xyz;
+            float3 lightC = LightColor.xyz;
+            float lum     = dot( color.xyz, 0.333333f ); // Image is greyscale, this is average
+            float adjDark = max( max( darkC.x, darkC.y ), darkC.z );
+            adjDark       = 1.0f / adjDark; // Scalar to always make color adjustment fullt saturated so it can be multiplied
+            darkC.xyz     *= adjDark;
+            float adjLight= max( max( lightC.x, lightC.y ), lightC.z );
+            adjLight      = 1.0f / adjLight; // Same scalar as Dark
+            lightC.xyz    *= adjLight;
+            blur.xyz      = lerp( darkC.xyz, lightC.xyz, lum ); // Create colored gradient
+        }
+        // Blending options
+        //float2 check      = float2( use_unblur, use_gradient );
+        if( use_unblur || use_gradient ) {
+            if( BlendMode == 0 ) {
+                blend.xyz     = blur.xyz;
+            }
+            if( BlendMode == 1 ) {
+                blend.xyz = darken( color.xyz, blur.xyz);
+            }
+            if( BlendMode == 2 ) {
+                blend.xyz = multiply( color.xyz, blur.xyz);
+            }
+            if( BlendMode == 3 ) {
+                blend.xyz = linearburn( color.xyz, blur.xyz);
+            }
+            if( BlendMode == 4 ) {
+                blend.xyz = colorburn( color.xyz, blur.xyz);
+            }
+            if( BlendMode == 5 ) {
+                blend.xyz = lighten( color.xyz, blur.xyz);
+            }
+            if( BlendMode == 6 ) {
+                blend.xyz = screen( color.xyz, blur.xyz);
+            }
+            if( BlendMode == 7 ) {
+                blend.xyz = colordodge( color.xyz, blur.xyz);
+            }
+            if( BlendMode == 8 ) {
+                blend.xyz = lineardodge( color.xyz, blur.xyz);
+            }
+            if( BlendMode == 9 ) {
+                blend.xyz = overlay( color.xyz, blur.xyz);
+            }
+            if( BlendMode == 10 ) {
+                blend.xyz = softlight( color.xyz, blur.xyz);
+            }
+            if( BlendMode == 11 ) {
+                blend.xyz = vividlight( color.xyz, blur.xyz);
+            }
+            if( BlendMode == 12 ) {
+                blend.xyz = linearlight( color.xyz, blur.xyz);
+            }
+            if( BlendMode == 13 ) {
+                blend.xyz = pinlight( color.xyz, blur.xyz);
+            }
+            color.xyz     = lerp( color.xyz, blend.xyz, opacity );
+        }
+        if( blendOrig ) {
+            blur.xyz      = orig.xyz;
+            if( flipColorBlend ) {
+                blur.xyz  = color.xyz;
+                color.xyz = orig.xyz;
+            }
+            if( BlendModeO == 0 ) {
+                blend.xyz     = blur.xyz;
+            }
+            if( BlendModeO == 1 ) {
+                blend.xyz = darken( color.xyz, blur.xyz);
+            }
+            if( BlendModeO == 2 ) {
+                blend.xyz = multiply( color.xyz, blur.xyz);
+            }
+            if( BlendModeO == 3 ) {
+                blend.xyz = linearburn( color.xyz, blur.xyz);
+            }
+            if( BlendModeO == 4 ) {
+                blend.xyz = colorburn( color.xyz, blur.xyz);
+            }
+            if( BlendModeO == 5 ) {
+                blend.xyz = lighten( color.xyz, blur.xyz);
+            }
+            if( BlendModeO == 6 ) {
+                blend.xyz = screen( color.xyz, blur.xyz);
+            }
+            if( BlendModeO == 7 ) {
+                blend.xyz = colordodge( color.xyz, blur.xyz);
+            }
+            if( BlendModeO == 8 ) {
+                blend.xyz = lineardodge( color.xyz, blur.xyz);
+            }
+            if( BlendModeO == 9 ) {
+                blend.xyz = overlay( color.xyz, blur.xyz);
+            }
+            if( BlendModeO == 10 ) {
+                blend.xyz = softlight( color.xyz, blur.xyz);
+            }
+            if( BlendModeO == 11 ) {
+                blend.xyz = vividlight( color.xyz, blur.xyz);
+            }
+            if( BlendModeO == 12 ) {
+                blend.xyz = linearlight( color.xyz, blur.xyz);
+            }
+            if( BlendModeO == 13 ) {
+                blend.xyz = pinlight( color.xyz, blur.xyz);
+            }
+            color.xyz     = lerp( color.xyz, blend.xyz, opacityO );
+        }
+        // Contrast & Brightness
+        color.xyz         = saturate( lerp( color.xyz, softlight( color.xyz, color.xyz ), contrast ));
+        color.xyz         = saturate( lerp( color.xyz, screen( color.xyz, color.xyz ), brightness ));
+        return float4( color.xyz, 1.0f ); // Final output
+    }
+
+    float4 PS_AfterFX_CA(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+    {
+        float4 color      = tex2D( samplerBlended, texcoord );
+        if( use_ca ) {
+            float3 orig   = color.xyz;
+            float CAwidth = CA;
+            float adj     = 1.0f;
+            float2 adjRad = 1.0f;
+            if( use_ca_edges ) {
+                float2 coords = texcoord.xy;
+                coords.xy     -= 0.5f;
+                adjRad.xy     = coords.xy * 2.0f;
+                coords.xy     = abs( coords.xy );
+                adj           = adj * pow( max( coords.x, coords.y ) * 2.0f, 0.5f );
+            }
+            float cos     = cos( radians( degrees )) * adjRad.x;
+            float sin     = sin( radians( degrees )) * adjRad.y;
+            color.x       = tex2D( samplerBlended, texcoord + float2( px * cos * CAwidth * adj, py * sin * CAwidth * adj )).x;
+            color.z       = tex2D( samplerBlended, texcoord - float2( px * cos * CAwidth * adj, py * sin * CAwidth * adj )).z;
+            color.xyz     = lerp( orig.xyz, color.xyz, CA_strength );
+        }
+        return float4( color.xyz, 1.0f );
+    }
+
+    float4 PS_AfterFX_Grain(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+    {
+        float4 color      = tex2D( samplerAfterFX1, texcoord );
+        if ( use_grain )
+        {
+            float3 rotOffset  = float3( 1.425f, 3.892f, 5.835f ); // Rotation offset values (RGB)
+            float2 rotCoordsR = coordRot( texcoord.xy, timer + rotOffset.x );
+            float2 rotCoordsG = coordRot( texcoord.xy, timer + rotOffset.y );
+            float2 rotCoordsB = coordRot( texcoord.xy, timer + rotOffset.z );
+            float3 noise      = pnoise3D( float3( rotCoordsR.xy * float2( BUFFER_WIDTH * 0.625f, BUFFER_HEIGHT * 0.625f ), 0.0f ), texcoord.xy); // 0.625f arbitrary value which gave good results. Rotation set to 0 degrees
+            noise.y           = pnoise3D( float3( rotCoordsG.xy * float2( BUFFER_WIDTH * 0.625f, BUFFER_HEIGHT * 0.625f ), 1.0f / 3.0f ), texcoord.xy); // rotated 120 degrees
+            noise.z           = pnoise3D( float3( rotCoordsB.xy * float2( BUFFER_WIDTH * 0.625f, BUFFER_HEIGHT * 0.625f ), 2.0f / 3.0f ), texcoord.xy); // rotated 240 degrees
+            noise.xyz         *= grainIntensity;
+            noise.xyz         = lerp( dot( noise.xyz, float3( 0.212656, 0.715158, 0.072186 )), noise.xyz, grainColor ); // Grey or color noise
+            float lum         = dot( color.xyz, 0.333333f ); // Just using average here
+            noise.xyz         = lerp( noise.xyz * grainIntLow, noise.xyz * grainIntHigh, fade( lum )); // Noise adjustments based on luma
+            color.xyz         = lerp( color.xyz, color.xyz + noise.xyz, grainAmount );
+        }
+        return float4( color.xyz, 1.0f );
+    }
+
+    //// TECHNIQUES /////////////////////////////////////////////////////////////////
+    technique prod80_04_Black_and_White
+    {
+        pass prod80_BlackandWhite
+        {
+            VertexShader  = PostProcessVS;
+            PixelShader   = PS_BlackandWhite;
+            RenderTarget  = texColorNew;
+        }
+        pass prod80_BlurH
+        {
+            VertexShader  = PostProcessVS;
+            PixelShader   = PS_GaussianH;
+            RenderTarget  = texBlurH;
+        }
+        pass prod80_Blur
+        {
+            VertexShader  = PostProcessVS;
+            PixelShader   = PS_GaussianV;
+            RenderTarget  = texBlur;
+        }
+        pass prod80_BlurDeband
+        {
+            VertexShader  = PostProcessVS;
+            PixelShader   = PS_BloomDeband;
+            RenderTarget  = texBlurDeband;
+        }
+        pass prod80_Blend
+        {
+            VertexShader  = PostProcessVS;
+            PixelShader   = PS_BlendImgBlur;
+            RenderTarget  = texBlended;
+        }
+        pass prod80_AfterFX1
+        {
+            VertexShader  = PostProcessVS;
+            PixelShader   = PS_AfterFX_CA;
+            RenderTarget  = texAfterFX1;
+        }
+        pass prod80_AfterFX2
+        {
+            VertexShader  = PostProcessVS;
+            PixelShader   = PS_AfterFX_Grain;
+        }
+    }
+}
+
+

--- a/Shaders/PD80 Contrasts & ColorFX.fx
+++ b/Shaders/PD80 Contrasts & ColorFX.fx
@@ -258,8 +258,8 @@ float PS_WriteCLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_T
 
 float PS_AvgCLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
 {
-  float luma       = tex2Dlod( samplerCLuma, float4(0.0f, 0.0f, 0, 8 )).x;
-  float prevluma   = tex2D( samplerCPrevAvgLuma, float2( 0.0f, 0.0f )).x;
+  float luma       = tex2Dlod( samplerCLuma, float4(0.5f, 0.5f, 0, 8 )).x;
+  float prevluma   = tex2D( samplerCPrevAvgLuma, float2( 0.5f, 0.5f )).x;
   luma             = exp2( luma );
   float fps        = 1000.0f / Frametime;
   fps              *= 0.5f; //approx. 1 second delay to change luma between bright and dark
@@ -270,7 +270,7 @@ float PS_AvgCLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Tar
 float4 PS_CC(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
 {
   float4 color     = tex2D( samplerColor, texcoord );
-  float avgluma    = tex2D( samplerCAvgLuma, float2( 0.0f, 0.0f )).x;
+  float avgluma    = tex2D( samplerCAvgLuma, float2( 0.5f, 0.5f )).x;
 
   if( enableKelvin == TRUE )
   {
@@ -371,7 +371,7 @@ float4 PS_CC(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
 
 float PS_PrevAvgCLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
 {
-  float avgLuma    = tex2D( samplerCAvgLuma, float2( 0.0f, 0.0f )).x;
+  float avgLuma    = tex2D( samplerCAvgLuma, float2( 0.5f, 0.5f )).x;
   return avgLuma;
 }
 
@@ -402,6 +402,3 @@ technique prod80_03_CurvesColors
     RenderTarget   = texCPrevAvgLuma;
   }
 }
-
-
-

--- a/Shaders/PD80 Contrasts & ColorFX.fx
+++ b/Shaders/PD80 Contrasts & ColorFX.fx
@@ -1,0 +1,405 @@
+/* 
+ Color Effects, Contrasts, and Brightness by prod80 for ReShade
+ Version 3.0
+*/
+
+#include "ReShade.fxh"
+#include "ReShadeUI.fxh"
+#include "PD80 HelperFunctions.fxh"
+
+//// UI ELEMENTS ////////////////////////////////////////////////////////////////
+//Kelvin
+uniform bool enableKelvin <
+  ui_label = "Enable Color Temp (K)";
+  ui_category = "Kelvin";
+  > = false;
+
+uniform uint Kelvin <
+  ui_label = "Color Temp (K)";
+  ui_category = "Kelvin";
+  ui_min = 1000;
+  ui_max = 40000;
+  > = 6500;
+
+uniform float LumPreservation <
+  ui_label = "Luminance Preservation";
+  ui_category = "Kelvin";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 1.0;
+  > = 1.0;
+
+uniform float kMix <
+  ui_label = "Mix with Original";
+  ui_category = "Kelvin";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 1.0;
+  > = 1.0;
+
+//Levels
+uniform bool enableLevels <
+  ui_label = "Enable Levels";
+  ui_category = "Levels";
+  > = true;
+
+uniform float3 inBlackRGB <
+  ui_type = "color";
+  ui_label = "Black IN";
+  ui_category = "Levels";
+  > = float3(0.0, 0.0, 0.0);
+
+uniform float3 inWhiteRGB <
+  ui_type = "color";
+  ui_label = "White IN";
+  ui_category = "Levels";
+  > = float3(1.0, 1.0, 1.0);
+
+uniform bool enableLumaOutBlack <
+  ui_label = "Allow average scene luminosity to influence Black OUT.\nWhen NOT selected Black OUT minimum is ignored.";
+  ui_category = "Levels";
+  > = false;
+
+uniform float3 outBlackRGBmin <
+  ui_type = "color";
+  ui_label = "Black OUT minimum";
+  ui_category = "Levels";
+  > = float3(0.016, 0.016, 0.016);
+
+uniform float3 outBlackRGBmax <
+  ui_type = "color";
+  ui_label = "Black OUT maximum";
+  ui_category = "Levels";
+  > = float3(0.028, 0.028, 0.028);
+
+uniform float3 outWhiteRGB <
+  ui_type = "color";
+  ui_label = "White OUT";
+  ui_category = "Levels";
+  > = float3(1.0, 1.0, 1.0);
+
+uniform float inGammaGray <
+  ui_label = "Gamma Adjustment";
+  ui_category = "Levels";
+  ui_type = "slider";
+  ui_min = 0.05;
+  ui_max = 10.0;
+  > = 1.0;
+
+//Color Isolation
+uniform bool enableColorIso <
+  ui_label = "Enable Color Isolation";
+  ui_category = "Color Isolation";
+  > = false;
+
+uniform float satLimit <
+  ui_label = "Saturation Output";
+  ui_category = "Color Isolation";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 1.0;
+  > = 1.0;
+
+uniform float hueMid <
+  ui_label = "Hue Selection (Middle)";
+  ui_category = "Color Isolation";
+  ui_tooltip = "0 = Red, 0.167 = Yellow, 0.333 = Green, 0.5 = Cyan, 0.666 = Blue, 0.833 = Magenta";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 1.0;
+  > = 0.0;
+
+uniform float hueRangeMin <
+  ui_label = "Hue Range Below Middle";
+  ui_category = "Color Isolation";
+  ui_tooltip = "Hues to process below Hue Selection";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 0.75;
+  > = 0.333;
+
+uniform float hueRangeMax <
+  ui_label = "Hue Range Above Middle";
+  ui_category = "Color Isolation";
+  ui_tooltip = "Hues to process above Hue Selection";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 0.75;
+  > = 0.333;
+
+uniform float fxcolorMix <
+  ui_label = "Mix with Original";
+  ui_category = "Color Isolation";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 1.0;
+  > = 1.0;
+
+//Gradients
+uniform bool enableGradients <
+  ui_label = "Enable Gradients";
+  ui_category = "Gradients";
+  > = false;
+
+uniform float3 midcolor <
+  ui_type = "color";
+  ui_label = "Mid Tone Color";
+  ui_category = "Gradients";
+  > = float3(1.0, 0.843, 0.2);
+
+uniform float3 shadowcolor <
+  ui_type = "color";
+  ui_label = "Shadow Color";
+  ui_category = "Gradients";
+  > = float3(1.0, 0.5, 0.9);
+
+uniform float midpower <
+  ui_label = "Mid Tone Power Distribution";
+  ui_category = "Gradients";
+  ui_type = "slider";
+  ui_min = 0.05;
+  ui_max = 5.0;
+  > = 2.0;
+
+uniform float shadowpower <
+  ui_label = "Shadow Power Distribution";
+  ui_category = "Gradients";
+  ui_type = "slider";
+  ui_min = 0.05;
+  ui_max = 5.0;
+  > = 2.0;
+
+uniform float finalmix <
+  ui_label = "Mix with Original";
+  ui_category = "Gradients";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 1.0;
+  > = 0.2;
+
+//LumaGradients
+uniform bool enableLumaGradients <
+  ui_label = "Enable Luma Gradients";
+  ui_tooltip = "Changes shadow colors based on average scene luminosity";
+  ui_category = "Luma Gradients";
+  > = false;
+
+uniform float3 LGShadowcolorL <
+  ui_type = "color";
+  ui_label = "Luminous Scene Shadow Color";
+  ui_category = "Luma Gradients";
+  > = float3(0.505, 0.483, 0.431);
+
+uniform float3 LGShadowcolorD <
+  ui_type = "color";
+  ui_label = "Dark Scene Shadow Color";
+  ui_category = "Luma Gradients";
+  > = float3(0.431, 0.483, 0.505);
+
+uniform float contrast <
+  ui_label = "Contrast";
+  ui_category = "Final Adjustments";
+  ui_type = "slider";
+  ui_min = -1.0;
+  ui_max = 2.0;
+  > = 0.0;
+
+uniform float brightness <
+  ui_label = "Brightness";
+  ui_category = "Final Adjustments";
+  ui_type = "slider";
+  ui_min = -1.0;
+  ui_max = 2.0;
+  > = 0.0;
+
+uniform float saturation <
+  ui_label = "Saturation";
+  ui_category = "Final Adjustments";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 2.0;
+  > = 1.0;
+
+
+//// TEXTURES ///////////////////////////////////////////////////////////////////
+texture texColorBuffer : COLOR;
+texture texDepthBuffer : DEPTH;
+texture texCLuma { Width = 256; Height = 256; Format = R16F; MipLevels = 8; };
+texture texCAvgLuma { Format = R16F; };
+texture texCPrevAvgLuma { Format = R16F; };
+
+//// SAMPLERS ///////////////////////////////////////////////////////////////////
+sampler samplerColor { Texture = texColorBuffer; };
+sampler samplerDepth { Texture = texDepthBuffer; };
+sampler samplerCLuma { Texture = texCLuma; };
+sampler samplerCAvgLuma { Texture = texCAvgLuma; };
+sampler samplerCPrevAvgLuma { Texture = texCPrevAvgLuma; };
+
+//// DEFINES ////////////////////////////////////////////////////////////////////
+//See PD80 HelperFunctions.fxh
+
+//// BUFFERS ////////////////////////////////////////////////////////////////////
+// Not supported in ReShade (?)
+
+//// FUNCTIONS //////////////////////////////////////////////////////////////////
+//See PD80 HelperFunctions.fxh
+
+//// COMPUTE SHADERS ////////////////////////////////////////////////////////////
+// Not supported in ReShade (?)
+
+//// PIXEL SHADERS //////////////////////////////////////////////////////////////
+float PS_WriteCLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+{
+  float4 color     = tex2D( samplerColor, texcoord );
+  float luma      = getLuminance( color.xyz );
+  return luma;
+}
+
+float PS_AvgCLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+{
+  float luma       = tex2Dlod( samplerCLuma, float4(0.0f, 0.0f, 0, 8 )).x;
+  float prevluma   = tex2D( samplerCPrevAvgLuma, float2( 0.0f, 0.0f )).x;
+  float fps        = 1000.0f / Frametime;
+  fps              *= 0.5f; //approx. 1 second delay to change luma between bright and dark
+  float avgLuma    = lerp( prevluma, luma, 1.0f / fps ); 
+  return avgLuma;
+}
+
+float4 PS_CC(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+{
+  float4 color     = tex2D( samplerColor, texcoord );
+  float avgluma    = tex2D( samplerCAvgLuma, float2( 0.0f, 0.0f )).x;
+
+  if( enableKelvin == TRUE )
+  {
+    float3 kColor  = KelvinToRGB( Kelvin );
+    float3 oLum    = RGBToHCV( color.xyz );
+    oLum.x         = oLum.z - oLum.y * 0.5f;
+    float3 blended = lerp( color.xyz, color.xyz * kColor.xyz, kMix );
+    float3 resHSL  = RGBToHSL( blended.xyz );
+    float3 resRGB  = HSLToRGB( float3( resHSL.x, resHSL.y, oLum.x ));
+    color.xyz      = lerp( blended.xyz, resRGB.xyz, LumPreservation );
+  }
+  
+  if( enableLevels == TRUE )
+  {
+    color.xyz      = max( color.xyz - inBlackRGB.xyz, 0.0f )/max( inWhiteRGB.xyz - inBlackRGB.xyz, 0.000001f );
+    color.xyz      = pow( color.xyz, inGammaGray );
+    float3 outBlack= outBlackRGBmax.xyz;
+    if( enableLumaOutBlack == TRUE )
+      outBlack.xyz = lerp( outBlackRGBmin.xyz, outBlackRGBmax.xyz, avgluma );
+    color.xyz      = color.xyz * max( outWhiteRGB.xyz - outBlack.xyz, 0.000001f ) + outBlack.xyz;
+    color.xyz      = max( color.xyz, 0.0f );
+  }
+ 
+  if( enableColorIso == TRUE )
+  {
+    color.xyz      = saturate( color.xyz ); //Can't work with HDR
+    float ci_gray  = getLuminance( color.xyz );
+    float ci_hue   = RGBToHSL( color.xyz ).x;
+    float2 limit   = float2( hueMid - hueRangeMin, hueMid + hueRangeMax );
+    float3 new_c   = 0.0f;
+    if( limit.y > 1.0f && ci_hue < limit.y - 1.0f )
+      ci_hue       += 1;
+    if( limit.x < 0.0f && ci_hue > limit.x + 1.0f )
+      ci_hue       -= 1;
+    if( ci_hue < hueMid )
+      new_c.xyz    = lerp( ci_gray, color.xyz, smootherstep( limit.x, hueMid, ci_hue ) * satLimit );
+    if( ci_hue >= hueMid )
+      new_c.xyz    = lerp( ci_gray, color.xyz, ( 1.0f - smootherstep( hueMid, limit.y, ci_hue )) * satLimit );
+    color.xyz      = lerp( color.xyz, new_c.xyz, fxcolorMix );
+  }
+  
+  if( enableGradients == TRUE )
+  {
+    color.xyz      = saturate( color.xyz );
+    //float avgcolor = dot( color.xyz, 0.333333f );
+    float avgcolor = Luminance( color.xyz );
+    float3 Ginten  = RGBToHCV( color.xyz );
+    Ginten.x       = Ginten.z - Ginten.y * 0.5f;
+    float low      = pow( 1.0f - avgcolor, shadowpower );
+    float high     = pow( avgcolor, midpower );
+    float mid      = saturate( 1.0f - low - high );
+    float3 midC    = max( midcolor.xyz, 0.000001f );   //avoid division by 0
+    float3 shaC    = max( shadowcolor.xyz, 0.000001f );  //ditto
+    float maxMid   = getMaxLuminance( midC.xyz );
+    float maxSha   = getMaxLuminance( shaC.xyz );
+    float3 cMid    = midC.xyz / maxMid;     //scale color where maximum has a value of 1
+    float3 cSha    = shaC.xyz / maxSha;     //ditto
+    float3 cg      = saturate( mid * cMid.xyz + low * cSha.xyz + high );
+    cg.xyz         = RGBToHSL( cg.xyz );
+    cg.xyz         = HSLToRGB( float3( cg.xy, Ginten.x )); //place back original intensity
+    color.xyz      = lerp( color.xyz, cg.xyz, finalmix );
+  }
+ 
+  if( enableLumaGradients == TRUE )
+  {
+    color.xyz      = saturate( color.xyz );
+    float LGlum    = Luminance( color.xyz );
+    float3 LGlum1  = RGBToHCV( color.xyz );
+    LGlum1.x       = LGlum1.z - LGlum1.y * 0.5f;
+    float3 LGShadowD = overlay( color.xyz, LGShadowcolorD.xyz );
+    LGShadowD.xyz  = RGBToHSL( LGShadowD.xyz );
+    LGShadowD.xyz  = HSLToRGB( float3( LGShadowD.xy, LGlum1.x ));
+    LGShadowD.xyz  = lerp( LGShadowD.xyz, color.xyz, LGlum );
+    float3 LGShadowL = overlay( color.xyz, LGShadowcolorL.xyz );
+    LGShadowL.xyz  = RGBToHSL( LGShadowL.xyz );
+    LGShadowL.xyz  = HSLToRGB( float3( LGShadowL.xy, LGlum1.x ));
+    LGShadowL.xyz  = lerp( LGShadowL.xyz, color.xyz, LGlum );
+    color.xyz      = lerp( LGShadowD.xyz, LGShadowL.xyz, avgluma );
+  }
+  
+ 
+  color.xyz        = saturate( lerp( color.xyz, softlight( color.xyz, color.xyz ), contrast ));
+  color.xyz        = saturate( lerp( color.xyz, screen( color.xyz, color.xyz ), brightness ));
+  float4 sat       = 0.0f;
+  sat.xy           = float2( min( min( color.x, color.y ), color.z ), max( max( color.x, color.y ), color.z ));
+  sat.z            = sat.y - sat.x;
+  sat.w            = getLuminance( color.xyz );
+  float3 min_sat   = lerp( sat.w, color.xyz, saturation );
+  float3 max_sat   = lerp( sat.w, color.xyz, 1.0f + ( saturation - 1.0f ) * ( 1.0f - sat.z ));
+  float3 neg       = min( max_sat.xyz + 1.0f, 1.0f );
+  neg.xyz          = saturate( 1.0f - neg.xyz );
+  float negsum     = dot( neg.xyz, 1.0f );
+  max_sat.xyz      = max( max_sat.xyz, 0.0f );
+  max_sat.xyz      = max_sat.xyz + saturate(sign( max_sat.xyz )) * negsum.xxx;
+  color.xyz        = saturate( lerp( min_sat.xyz, max_sat.xyz, step( 1.0f, saturation )));
+  return float4( color.xyz, 1.0f );
+}
+
+float PS_PrevAvgCLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+{
+  float avgLuma    = tex2D( samplerCAvgLuma, float2( 0.0f, 0.0f )).x;
+  return avgLuma;
+}
+
+//// TECHNIQUES /////////////////////////////////////////////////////////////////
+technique prod80_03_CurvesColors
+{
+  pass CLuma
+  {
+    VertexShader   = PostProcessVS;
+    PixelShader    = PS_WriteCLuma;
+    RenderTarget   = texCLuma;
+  }
+  pass AvgCLuma
+  {
+    VertexShader   = PostProcessVS;
+    PixelShader    = PS_AvgCLuma;
+    RenderTarget   = texCAvgLuma;
+  }
+  pass CurvesAndColors
+  {
+    VertexShader   = PostProcessVS;
+    PixelShader    = PS_CC;
+  }
+  pass PreviousCLuma
+  {
+    VertexShader   = PostProcessVS;
+    PixelShader    = PS_PrevAvgCLuma;
+    RenderTarget   = texCPrevAvgLuma;
+  }
+}
+
+
+

--- a/Shaders/PD80 Contrasts & ColorFX.fx
+++ b/Shaders/PD80 Contrasts & ColorFX.fx
@@ -1,6 +1,6 @@
 /* 
  Color Effects, Contrasts, and Brightness by prod80 for ReShade
- Version 3.0
+ Version 4.0
 */
 
 #include "ReShade.fxh"
@@ -58,7 +58,7 @@ uniform float3 inWhiteRGB <
 uniform bool enableLumaOutBlack <
   ui_label = "Allow average scene luminosity to influence Black OUT.\nWhen NOT selected Black OUT minimum is ignored.";
   ui_category = "Levels";
-  > = false;
+  > = true;
 
 uniform float3 outBlackRGBmin <
   ui_type = "color";
@@ -70,7 +70,7 @@ uniform float3 outBlackRGBmax <
   ui_type = "color";
   ui_label = "Black OUT maximum";
   ui_category = "Levels";
-  > = float3(0.028, 0.028, 0.028);
+  > = float3(0.036, 0.036, 0.036);
 
 uniform float3 outWhiteRGB <
   ui_type = "color";
@@ -251,14 +251,16 @@ sampler samplerCPrevAvgLuma { Texture = texCPrevAvgLuma; };
 float PS_WriteCLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
 {
   float4 color     = tex2D( samplerColor, texcoord );
-  float luma      = getLuminance( color.xyz );
-  return luma;
+  color.xyz        = SRGBToLinear( color.xyz );
+  float luma       = getLuminance( color.xyz );
+  return log2( max( luma, 0.001f ));
 }
 
 float PS_AvgCLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
 {
   float luma       = tex2Dlod( samplerCLuma, float4(0.0f, 0.0f, 0, 8 )).x;
   float prevluma   = tex2D( samplerCPrevAvgLuma, float2( 0.0f, 0.0f )).x;
+  luma             = exp2( luma );
   float fps        = 1000.0f / Frametime;
   fps              *= 0.5f; //approx. 1 second delay to change luma between bright and dark
   float avgLuma    = lerp( prevluma, luma, 1.0f / fps ); 

--- a/Shaders/PD80 Filmic Adaptation.fx
+++ b/Shaders/PD80 Filmic Adaptation.fx
@@ -1,13 +1,13 @@
 /* 
   Filmic tonemapper with exposure correction by prod80 for ReShade
-  Version 3.0
+  Version 4.0
 
   Sources/credits
   For the methods : https://placeholderart.wordpress.com/2014/11/21/implementing-a-physically-based-camera-manual-exposure/
   For the methods : https://placeholderart.wordpress.com/2014/12/15/implementing-a-physically-based-camera-automatic-exposure/
   For the logic : https://github.com/TheRealMJP/BakingLab/blob/master/BakingLab/Exposure.hlsl
  
-  Exposure code from MJP and David Neubelt, copyrighted under MIT License (see EOF)
+  Exposure code from MJP and David Neubelt, copyrighted under MIT License
   And John Hable for the tonemap method from UNCHARTED2
 */
 
@@ -110,7 +110,7 @@ uniform float setDelay <
   ui_type = "slider";
   ui_min = 0.1;
   ui_max = 5.0;
-  > = 1.5;
+  > = 1.0;
 
 uniform float GreyValue <
   ui_label = "50% Grey Value";
@@ -151,14 +151,16 @@ sampler samplerPrevAvgLuma { Texture = texPrevAvgLuma; };
 float PS_WriteLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
 {
   float4 color     = tex2D( samplerColor, texcoord );
-  float luma       = getMaxLuminance( color.xyz );
+  color.xyz        = SRGBToLinear( color.xyz );
+  float luma       = getLuminance( color.xyz );
   luma             = max( luma, 0.06f ); //hackjob until better solution
-  return luma;
+  return log2( luma );
 }
 
 float PS_AvgLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
 {
   float luma       = tex2Dlod( samplerLuma, float4(0.0f, 0.0f, 0, 8 )).x;
+  luma             = exp2( luma );
   float prevluma   = tex2D( samplerPrevAvgLuma, float2( 0.0f, 0.0f )).x;
   float fps        = 1000.0f / Frametime;
   float delay      = fps * ( setDelay / 2.0f );	
@@ -213,14 +215,5 @@ technique prod80_02_FilmicTonemap
   }
 }
 
-//Exposure code
-//=================================================================================================
-//
-//  Baking Lab
-//  by MJP and David Neubelt
-//  http://mynameismjp.wordpress.com/
-//
-//  All code licensed under the MIT license
-//
-//=================================================================================================
+
 

--- a/Shaders/PD80 Filmic Adaptation.fx
+++ b/Shaders/PD80 Filmic Adaptation.fx
@@ -159,9 +159,9 @@ float PS_WriteLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Ta
 
 float PS_AvgLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
 {
-  float luma       = tex2Dlod( samplerLuma, float4(0.0f, 0.0f, 0, 8 )).x;
+  float luma       = tex2Dlod( samplerLuma, float4(0.5f, 0.5f, 0, 8 )).x;
   luma             = exp2( luma );
-  float prevluma   = tex2D( samplerPrevAvgLuma, float2( 0.0f, 0.0f )).x;
+  float prevluma   = tex2D( samplerPrevAvgLuma, float2( 0.5f, 0.5f )).x;
   float fps        = 1000.0f / Frametime;
   float delay      = fps * ( setDelay / 2.0f );	
   float avgLuma    = lerp( prevluma, luma, 1.0f / delay );
@@ -171,7 +171,7 @@ float PS_AvgLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Targ
 float4 PS_Tonemap(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
 {
   float4 color     = tex2D( samplerColor, texcoord );
-  float lumaMod    = tex2D( samplerAvgLuma, float2( 0.0f, 0.0f )).x;
+  float lumaMod    = tex2D( samplerAvgLuma, float2( 0.5f, 0.5f )).x;
   lumaMod          = max( lumaMod, adaptationMin );
   lumaMod          = min( lumaMod, adaptationMax );
   color.xyz        = SRGBToLinear( color.xyz );
@@ -183,7 +183,7 @@ float4 PS_Tonemap(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Tar
 
 float PS_PrevAvgLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
 {
-  float avgLuma    = tex2D( samplerAvgLuma, float2( 0.0f, 0.0f )).x;
+  float avgLuma    = tex2D( samplerAvgLuma, float2( 0.5f, 0.5f )).x;
   return avgLuma;
 }
 
@@ -214,6 +214,3 @@ technique prod80_02_FilmicTonemap
     RenderTarget   = texPrevAvgLuma;
   }
 }
-
-
-

--- a/Shaders/PD80 Filmic Adaptation.fx
+++ b/Shaders/PD80 Filmic Adaptation.fx
@@ -1,0 +1,226 @@
+/* 
+  Filmic tonemapper with exposure correction by prod80 for ReShade
+  Version 3.0
+
+  Sources/credits
+  For the methods : https://placeholderart.wordpress.com/2014/11/21/implementing-a-physically-based-camera-manual-exposure/
+  For the methods : https://placeholderart.wordpress.com/2014/12/15/implementing-a-physically-based-camera-automatic-exposure/
+  For the logic : https://github.com/TheRealMJP/BakingLab/blob/master/BakingLab/Exposure.hlsl
+ 
+  Exposure code from MJP and David Neubelt, copyrighted under MIT License (see EOF)
+  And John Hable for the tonemap method from UNCHARTED2
+*/
+
+#include "ReShade.fxh"
+#include "ReShadeUI.fxh"
+#include "PD80 HelperFunctions.fxh"
+
+//// UI ELEMENTS ////////////////////////////////////////////////////////////////
+uniform float shoulder <
+  ui_label = "A: Adjust Shoulder";
+  ui_tooltip = "Highlights";
+  ui_category = "Tonemapping";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 5.0;
+  > = 0.115;
+
+uniform float linear_str <
+  ui_label = "B: Adjust Linear Strength";
+  ui_tooltip = "Curve Linearity";
+  ui_category = "Tonemapping";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 5.0;
+  > = 0.065;
+
+uniform float angle <
+  ui_label = "C: Adjust Angle";
+  ui_tooltip = "Curve Angle";
+  ui_category = "Tonemapping";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 5.0;
+  > = 0.43;
+
+uniform float toe <
+  ui_label = "D: Adjust Toe";
+  ui_tooltip = "Shadows";
+  ui_category = "Tonemapping";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 5.0;
+  > = 0.65;
+
+uniform float toe_num <
+  ui_label = "E: Adjust Toe Numerator";
+  ui_tooltip = "Shadow Curve";
+  ui_category = "Tonemapping";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 5.0;
+  > = 0.07;
+
+uniform float toe_denom <
+  ui_label = "F: Adjust Toe Denominator";
+  ui_tooltip = "Shadow Curve (must be more than E)";
+  ui_category = "Tonemapping";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 5.0;
+  > = 0.41;
+
+uniform float white <
+  ui_label = "White Level";
+  ui_tooltip = "White Limiter";
+  ui_category = "Tonemapping";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 20.0;
+  > = 1.32;
+
+uniform float exposureMod <
+  ui_label = "Exposure";
+  ui_tooltip = "Exposure Adjustment";
+  ui_category = "Tonemapping";
+  ui_type = "slider";
+  ui_min = -2.0;
+  ui_max = 2.0;
+  > = 0.0;
+
+uniform float adaptationMin <
+  ui_label = "Minimum Exposure Adaptation";
+  ui_category = "Tonemapping";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 1.0;
+  > = 0.42;
+
+uniform float adaptationMax <
+  ui_label = "Maximum Exposure Adaptation";
+  ui_category = "Tonemapping";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 1.0;
+  > = 0.6;
+
+uniform float setDelay <
+  ui_label = "Adaptation Time Delay (sec)";
+  ui_category = "Tonemapping";
+  ui_type = "slider";
+  ui_min = 0.1;
+  ui_max = 5.0;
+  > = 1.5;
+
+uniform float GreyValue <
+  ui_label = "50% Grey Value";
+  ui_tooltip = "Target Grey Value used for exposure";
+  ui_category = "Tonemapping";
+  ui_type = "slider";
+  ui_min = 0;
+  ui_max = 1;
+  > = 0.735;
+
+//// TEXTURES ///////////////////////////////////////////////////////////////////
+texture texColorBuffer : COLOR;
+texture texDepthBuffer : DEPTH;
+texture texLuma { Width = 256; Height = 256; Format = R16F; MipLevels = 8; };
+texture texAvgLuma { Format = R16F; };
+texture texPrevAvgLuma { Format = R16F; };
+
+//// SAMPLERS ///////////////////////////////////////////////////////////////////
+sampler samplerColor { Texture = texColorBuffer; };
+sampler samplerDepth { Texture = texDepthBuffer; };
+sampler samplerLuma { Texture = texLuma; };
+sampler samplerAvgLuma { Texture = texAvgLuma; };
+sampler samplerPrevAvgLuma { Texture = texPrevAvgLuma; };
+
+//// DEFINES ////////////////////////////////////////////////////////////////////
+//See PD80 HelperFunctions.fxh
+
+//// BUFFERS ////////////////////////////////////////////////////////////////////
+// Not supported in ReShade (?)
+
+//// FUNCTIONS //////////////////////////////////////////////////////////////////
+//See PD80 HelperFunctions.fxh
+
+//// COMPUTE SHADERS ////////////////////////////////////////////////////////////
+// Not supported in ReShade (?)
+
+//// PIXEL SHADERS //////////////////////////////////////////////////////////////
+float PS_WriteLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+{
+  float4 color     = tex2D( samplerColor, texcoord );
+  float luma       = getMaxLuminance( color.xyz );
+  luma             = max( luma, 0.06f ); //hackjob until better solution
+  return luma;
+}
+
+float PS_AvgLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+{
+  float luma       = tex2Dlod( samplerLuma, float4(0.0f, 0.0f, 0, 8 )).x;
+  float prevluma   = tex2D( samplerPrevAvgLuma, float2( 0.0f, 0.0f )).x;
+  float fps        = 1000.0f / Frametime;
+  float delay      = fps * ( setDelay / 2.0f );	
+  float avgLuma    = lerp( prevluma, luma, 1.0f / delay );
+  return avgLuma;
+}
+
+float4 PS_Tonemap(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+{
+  float4 color     = tex2D( samplerColor, texcoord );
+  float lumaMod    = tex2D( samplerAvgLuma, float2( 0.0f, 0.0f )).x;
+  lumaMod          = max( lumaMod, adaptationMin );
+  lumaMod          = min( lumaMod, adaptationMax );
+  color.xyz        = SRGBToLinear( color.xyz );
+  color.xyz        = CalcExposedColor( color.xyz, lumaMod, exposureMod, GreyValue );
+  color.xyz        = Filmic( color.xyz, shoulder, linear_str, angle, toe, toe_num, toe_denom, white );
+  
+  return float4( color.xyz, 1.0f );
+}
+
+float PS_PrevAvgLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+{
+  float avgLuma    = tex2D( samplerAvgLuma, float2( 0.0f, 0.0f )).x;
+  return avgLuma;
+}
+
+//// TECHNIQUES /////////////////////////////////////////////////////////////////
+technique prod80_02_FilmicTonemap
+{
+  pass Luma
+  {
+    VertexShader   = PostProcessVS;
+    PixelShader    = PS_WriteLuma;
+    RenderTarget   = texLuma;
+  }
+  pass AvgLuma
+  {
+    VertexShader   = PostProcessVS;
+    PixelShader    = PS_AvgLuma;
+    RenderTarget   = texAvgLuma;
+  }
+  pass Tonemapping
+  {
+    VertexShader   = PostProcessVS;
+    PixelShader    = PS_Tonemap;
+  }
+  pass PreviousLuma
+  {
+    VertexShader   = PostProcessVS;
+    PixelShader    = PS_PrevAvgLuma;
+    RenderTarget   = texPrevAvgLuma;
+  }
+}
+
+//Exposure code
+//=================================================================================================
+//
+//  Baking Lab
+//  by MJP and David Neubelt
+//  http://mynameismjp.wordpress.com/
+//
+//  All code licensed under the MIT license
+//
+//=================================================================================================
+

--- a/Shaders/PD80 HQ Bloom.fx
+++ b/Shaders/PD80 HQ Bloom.fx
@@ -230,9 +230,9 @@ float PS_WriteBLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_T
 
 float PS_AvgBLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
 {
-  float luma       = tex2Dlod( samplerBLuma, float4(0.0f, 0.0f, 0, 8 )).x;
+  float luma       = tex2Dlod( samplerBLuma, float4(0.5f, 0.5f, 0, 8 )).x;
   luma             = exp2( luma );
-  float prevluma   = tex2D( samplerBPrevAvgLuma, float2( 0.0f, 0.0f )).x;
+  float prevluma   = tex2D( samplerBPrevAvgLuma, float2( 0.5f, 0.5f )).x;
   float fps        = 1000.0f / Frametime;
   fps              *= 0.5f; //approx. 1 second delay to change luma between bright and dark
   float avgLuma    = lerp( prevluma, luma, 1.0f / fps ); 
@@ -242,7 +242,7 @@ float PS_AvgBLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Tar
 float4 PS_BloomIn(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
 {
   float4 color     = tex2D( samplerColor, texcoord );
-  float luma       = tex2D( samplerBAvgLuma, float2( 0.0f, 0.0f )).x;
+  float luma       = tex2D( samplerBAvgLuma, float2( 0.5f, 0.5f )).x;
   color.xyz        = max( color.xyz - luma, 0.0f );
   color.xyz        = SRGBToLinear( color.xyz );
   color.xyz        = CalcExposedColor( color.xyz, luma, 0.0f, GreyValue );
@@ -275,14 +275,14 @@ float4 PS_GaussianH(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_T
   for( int i = 0; i < LOOPCOUNT && SigmaSum < Q; ++i )
   {
     buffSigma.x    = Sigma.x * Sigma.y;
-	  calcOffset     = pxlOffset - 1.0f + buffSigma.x / Sigma.x;
-	  buffSigma.y    = Sigma.x + buffSigma.x;
+    calcOffset     = pxlOffset - 1.0f + buffSigma.x / Sigma.x;
+    buffSigma.y    = Sigma.x + buffSigma.x;
     color          += tex2D( samplerBloomIn, texcoord.xy + float2( calcOffset*px, 0.0f )) * buffSigma.y;
     color          += tex2D( samplerBloomIn, texcoord.xy - float2( calcOffset*px, 0.0f )) * buffSigma.y;
     SigmaSum       += ( 2.0f * Sigma.x + 2.0f * buffSigma.x );
     pxlOffset      += 2.0f;
     Sigma.xy       *= Sigma.yz;
-	  Sigma.xy       *= Sigma.yz;
+    Sigma.xy       *= Sigma.yz;
   }
  
   color.xyz        /= SigmaSum;
@@ -314,14 +314,14 @@ float4 PS_GaussianV(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_T
   for( int i = 0; i < LOOPCOUNT && SigmaSum < Q; ++i )
   {
     buffSigma.x    = Sigma.x * Sigma.y;
-	  calcOffset     = pxlOffset - 1.0f + buffSigma.x / Sigma.x;
-	  buffSigma.y    = Sigma.x + buffSigma.x;
-	  color          += tex2D( samplerBloomH, texcoord.xy + float2( 0.0f, calcOffset*py )) * buffSigma.y;
+    calcOffset     = pxlOffset - 1.0f + buffSigma.x / Sigma.x;
+    buffSigma.y    = Sigma.x + buffSigma.x;
+    color          += tex2D( samplerBloomH, texcoord.xy + float2( 0.0f, calcOffset*py )) * buffSigma.y;
     color          += tex2D( samplerBloomH, texcoord.xy - float2( 0.0f, calcOffset*py )) * buffSigma.y;
     SigmaSum       += ( 2.0f * Sigma.x + 2.0f * buffSigma.x );
     pxlOffset      += 2.0f;
     Sigma.xy       *= Sigma.yz;
-	  Sigma.xy       *= Sigma.yz;
+    Sigma.xy       *= Sigma.yz;
   }
  
   color.xyz        /= SigmaSum;
@@ -339,25 +339,25 @@ float4 PS_Gaussian(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Ta
     float maxdiff;
     float middiff;
     if (threshold_preset == 0)
-	  {
+	{
       avgdiff      = 0.6f;
       maxdiff      = 1.9f;
       middiff      = 1.2f;
     }
     else if (threshold_preset == 1)
-  	{
+	{
       avgdiff      = 1.8f;
       maxdiff      = 4.0f;
       middiff      = 2.0f;
     }
     else if (threshold_preset == 2)
-    {
+	{
       avgdiff      = 3.4f;
       maxdiff      = 6.8f;
       middiff      = 3.3f;
     }
     else if (threshold_preset == 3)
-    {
+	{
       avgdiff      = custom_avgdiff;
       maxdiff      = custom_maxdiff;
       middiff      = custom_middiff;
@@ -381,11 +381,11 @@ float4 PS_Gaussian(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Ta
     float3 res; // Final pixel
 
     // Compute a random angle
-    float dir      = rand( permute( h )) * 6.2831853f;
-    float2 o       = float2( cos( dir ), sin( dir ));
+    float dir  = rand( permute( h )) * 6.2831853f;
+    float2 o = float2( cos( dir ), sin( dir ));
 
     for ( int i = 1; i <= iterations; ++i )
-	  {
+	{
       // Compute a random distance
       float dist   = rand(h) * range * i;
       float2 pt    = dist * ReShade::PixelSize;
@@ -452,7 +452,7 @@ float4 PS_Gaussian(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Ta
 
 float PS_PrevAvgBLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
 {
-  float avgLuma    = tex2D( samplerBAvgLuma, float2( 0.0f, 0.0f )).x;
+  float avgLuma    = tex2D( samplerBAvgLuma, float2( 0.5f, 0.5f )).x;
   return avgLuma;
 }
 

--- a/Shaders/PD80 HQ Bloom.fx
+++ b/Shaders/PD80 HQ Bloom.fx
@@ -1,0 +1,504 @@
+ /* 
+ * HQ Bloom by prod80 for ReShade
+ * Version 3.0
+ * 
+ * Additional credits:
+ *
+ * Deband shader by haasn
+ * https://github.com/haasn/gentoo-conf/blob/xor/home/nand/.mpv/shaders/deband-pre.glsl
+ *
+ * Copyright (c) 2015 Niklas Haas
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Modified and optimized for ReShade by JPulowski
+ * https://reshade.me/forum/shader-presentation/768-deband
+ *
+ * Do not distribute without giving credit to the original author(s).
+ */
+
+#include "ReShade.fxh"
+#include "ReShadeUI.fxh"
+#include "PD80 HelperFunctions.fxh"
+
+//// UI ELEMENTS ////////////////////////////////////////////////////////////////
+uniform bool debugBloom <
+  ui_label  = "Show only bloom on screen";
+  ui_category = "Bloom debug";
+  > = false;
+
+uniform float BloomMix <
+  ui_label = "Bloom Mix";
+  ui_tooltip = "...";
+  ui_category = "Bloom";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 1.0;
+  > = 0.4;
+
+uniform float BloomLimit <
+  ui_label = "Bloom Threshold";
+  ui_tooltip = "The maximum level of Bloom";
+  ui_category = "Bloom";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 1.0;
+  > = 0.15;
+
+uniform float GreyValue <
+  ui_label = "Bloom Exposure";
+  ui_tooltip = "Bloom Exposure Compensation";
+  ui_category = "Bloom";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 1.0;
+  > = 0.5;
+
+uniform float BlurSigma <
+  ui_label = "Bloom Width";
+  ui_tooltip = "...";
+  ui_category = "Bloom";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 80.0;
+  > = 30.0;
+
+uniform bool enableBKelvin <
+  ui_label  = "Enable Bloom Color Temp (K)";
+  ui_category = "Bloom Color Temperature";
+  > = false;
+
+uniform uint BKelvin <
+  ui_label = "Bloom Color Temp (K)";
+  ui_category = "Bloom Color Temperature";
+  ui_min = 1000;
+  ui_max = 40000;
+  > = 6500;
+
+uniform bool enableBDeband <
+  ui_label  = "Enable Bloom Deband";
+  ui_category = "Bloom Deband";
+  > = true;
+
+uniform int threshold_preset < __UNIFORM_COMBO_INT1
+  ui_label = "Debanding strength";
+  ui_category = "Bloom Deband";
+  ui_items = "Low\0Medium\0High\0Custom\0";
+  ui_tooltip = "Debanding presets. Use Custom to be able to use custom thresholds in the advanced section.";
+  > = 2;
+
+uniform float range < __UNIFORM_SLIDER_FLOAT1
+  ui_min = 1.0;
+  ui_max = 32.0;
+  ui_step = 1.0;
+  ui_label = "Initial radius";
+  ui_category = "Bloom Deband";
+  ui_tooltip = "The radius increases linearly for each iteration. A higher radius will find more gradients, but a lower radius will smooth more aggressively.";
+  > = 16.0;
+
+uniform int iterations < __UNIFORM_SLIDER_INT1
+  ui_min = 1;
+  ui_max = 4;
+  ui_label = "Iterations";
+  ui_category = "Bloom Deband";
+  ui_tooltip = "The number of debanding steps to perform per sample. Each step reduces a bit more banding, but takes time to compute.";
+  > = 4;
+
+uniform float custom_avgdiff < __UNIFORM_SLIDER_FLOAT1
+  ui_min = 0.0;
+  ui_max = 255.0;
+  ui_step = 0.1;
+  ui_label = "Average threshold";
+  ui_category = "Bloom Deband";
+  ui_tooltip = "Threshold for the difference between the average of reference pixel values and the original pixel value. Higher numbers increase the debanding strength but progressively diminish image details. In pixel shaders a 8-bit color step equals to 1.0/255.0";
+  ui_category = "Advanced";
+  > = 1.8;
+
+uniform float custom_maxdiff < __UNIFORM_SLIDER_FLOAT1
+  ui_min = 0.0;
+  ui_max = 255.0;
+  ui_step = 0.1;
+  ui_label = "Maximum threshold";
+  ui_category = "Bloom Deband";
+  ui_tooltip = "Threshold for the difference between the maximum difference of one of the reference pixel values and the original pixel value. Higher numbers increase the debanding strength but progressively diminish image details. In pixel shaders a 8-bit color step equals to 1.0/255.0";
+  ui_category = "Advanced";
+  > = 4.0;
+
+uniform float custom_middiff < __UNIFORM_SLIDER_FLOAT1
+  ui_min = 0.0;
+  ui_max = 255.0;
+  ui_step = 0.1;
+  ui_label = "Middle threshold";
+  ui_category = "Bloom Deband";
+  ui_tooltip = "Threshold for the difference between the average of diagonal reference pixel values and the original pixel value. Higher numbers increase the debanding strength but progressively diminish image details. In pixel shaders a 8-bit color step equals to 1.0/255.0";
+  ui_category = "Advanced";
+  > = 2.0;
+
+//// TEXTURES ///////////////////////////////////////////////////////////////////
+texture texColorBuffer : COLOR;
+texture texDepthBuffer : DEPTH;
+texture texBLuma { Width = 256; Height = 256; Format = R16F; MipLevels = 8; };
+texture texBAvgLuma { Format = R16F; };
+texture texBPrevAvgLuma { Format = R16F; };
+texture texBloomIn { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; }; 
+texture texBloomH { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; }; 
+texture texBloom { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; }; 
+
+//// SAMPLERS ///////////////////////////////////////////////////////////////////
+sampler samplerColor { Texture = texColorBuffer; };
+sampler samplerDepth { Texture = texDepthBuffer; };
+sampler samplerBLuma { Texture = texBLuma; };
+sampler samplerBAvgLuma { Texture = texBAvgLuma; };
+sampler samplerBPrevAvgLuma { Texture = texBPrevAvgLuma; };
+sampler samplerBloomIn { Texture = texBloomIn; };
+sampler samplerBloomH { Texture = texBloomH; };
+sampler samplerBloom { Texture = texBloom; };
+
+//// DEFINES ////////////////////////////////////////////////////////////////////
+//See PD80 HelperFunctions.fxh
+
+//// BUFFERS ////////////////////////////////////////////////////////////////////
+// Not supported in ReShade (?)
+
+//// FUNCTIONS //////////////////////////////////////////////////////////////////
+//See PD80 HelperFunctions.fxh
+
+void analyze_pixels(float3 ori, sampler2D tex, float2 texcoord, float2 _range, float2 dir, out float3 ref_avg, out float3 ref_avg_diff, out float3 ref_max_diff, out float3 ref_mid_diff1, out float3 ref_mid_diff2)
+{
+  // Sample at quarter-turn intervals around the source pixel
+
+  // South-east
+  float3 ref       = tex2Dlod( tex, float4( texcoord + _range * dir, 0.0f, 0.0f )).rgb;
+  float3 diff      = abs( ori - ref );
+  ref_max_diff     = diff;
+  ref_avg          = ref;
+  ref_mid_diff1    = ref;
+
+  // North-west
+  ref              = tex2Dlod( tex, float4( texcoord + _range * -dir, 0.0f, 0.0f )).rgb;
+  diff             = abs( ori - ref );
+  ref_max_diff     = max( ref_max_diff, diff );
+  ref_avg          += ref;
+  ref_mid_diff1    = abs((( ref_mid_diff1 + ref ) * 0.5f ) - ori );
+
+  // North-east
+  ref              = tex2Dlod( tex, float4( texcoord + _range * float2( -dir.y, dir.x ), 0.0f, 0.0f )).rgb;
+  diff             = abs( ori - ref );
+  ref_max_diff     = max( ref_max_diff, diff );
+  ref_avg          += ref;
+  ref_mid_diff2    = ref;
+
+    // South-west
+  ref              = tex2Dlod( tex, float4( texcoord + _range * float2( dir.y, -dir.x ), 0.0f, 0.0f )).rgb;
+  diff             = abs( ori - ref );
+  ref_max_diff     = max( ref_max_diff, diff );
+  ref_avg          += ref;
+  ref_mid_diff2    = abs((( ref_mid_diff2 + ref ) * 0.5f ) - ori );
+
+  ref_avg          *= 0.25f; // Normalize avg
+  ref_avg_diff     = abs( ori - ref_avg );
+}
+
+//// COMPUTE SHADERS ////////////////////////////////////////////////////////////
+// Not supported in ReShade (?)
+
+//// PIXEL SHADERS //////////////////////////////////////////////////////////////
+float PS_WriteBLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+{
+  float4 color     = tex2D( samplerColor, texcoord );
+  float luma       = getMaxLuminance( color.xyz );
+  luma             = max( luma, 0.06f ); //hackjob until better solution
+  return luma;
+}
+
+float PS_AvgBLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+{
+  float luma       = tex2Dlod( samplerBLuma, float4(0.0f, 0.0f, 0, 8 )).x;
+  float prevluma   = tex2D( samplerBPrevAvgLuma, float2( 0.0f, 0.0f )).x;
+  float fps        = 1000.0f / Frametime;
+  fps              *= 0.5f; //approx. 1 second delay to change luma between bright and dark
+  float avgLuma    = lerp( prevluma, luma, 1.0f / fps ); 
+  return avgLuma;
+}
+
+float4 PS_BloomIn(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+{
+  float4 color     = tex2D( samplerColor, texcoord );
+  float luma       = tex2D( samplerBAvgLuma, float2( 0.0f, 0.0f )).x;
+  color.xyz        = max( color.xyz - max( luma, BloomLimit ), 0.0f );
+  color.xyz        = SRGBToLinear( color.xyz );
+  color.xyz        = CalcExposedColor( color.xyz, luma, 0.0f, GreyValue );
+  color.xyz        = LinearTosRGB( color.xyz );
+  return float4( color.xyz, 1.0f ); 
+}
+
+float4 PS_GaussianH(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+{
+  float4 color     = tex2D( samplerBloomIn, texcoord );
+  float px         = 1.0f / BUFFER_WIDTH;
+  float SigmaSum   = 0.0f;
+  float pxlOffset  = 1.5f;
+  float calcOffset = 0.0f;
+  float2 buffSigma = 0.0f;
+  
+  //Gaussian Math
+  float3 Sigma;
+  Sigma.x          = 1.0f / ( sqrt( 2.0f * PI ) * BlurSigma );
+  Sigma.y          = exp( -0.5f / ( BlurSigma * BlurSigma ));
+  Sigma.z          = Sigma.y * Sigma.y;
+ 
+  //Center Weight
+  color.xyz        *= Sigma.x;
+  //Adding to total sum of distributed weights
+  SigmaSum         += Sigma.x;
+  //Setup next weight
+  Sigma.xy         *= Sigma.yz;
+ 
+  for( int i = 0; i < LOOPCOUNT && SigmaSum < Q; ++i )
+  {
+    buffSigma.x    = Sigma.x * Sigma.y;
+	calcOffset     = pxlOffset - 1.0f + buffSigma.x / Sigma.x;
+	buffSigma.y    = Sigma.x + buffSigma.x;
+    color          += tex2D( samplerBloomIn, texcoord.xy + float2( calcOffset*px, 0.0f )) * buffSigma.y;
+    color          += tex2D( samplerBloomIn, texcoord.xy - float2( calcOffset*px, 0.0f )) * buffSigma.y;
+    SigmaSum       += ( 2.0f * Sigma.x + 2.0f * buffSigma.x );
+    pxlOffset      += 2.0f;
+    Sigma.xy       *= Sigma.yz;
+	Sigma.xy       *= Sigma.yz;
+  }
+ 
+  color.xyz        /= SigmaSum;
+  return float4( color.xyz, 1.0f );
+}
+
+float4 PS_GaussianV(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+{
+  float4 color     = tex2D( samplerBloomH, texcoord );
+  float py         = 1.0f / BUFFER_HEIGHT;
+  float SigmaSum   = 0.0f;
+  float pxlOffset  = 1.5f;
+  float calcOffset = 0.0f;
+  float2 buffSigma = 0.0f;
+  
+  //Gaussian Math
+  float3 Sigma;
+  Sigma.x          = 1.0f / ( sqrt( 2.0f * PI ) * BlurSigma );
+  Sigma.y          = exp( -0.5f / ( BlurSigma * BlurSigma ));
+  Sigma.z          = Sigma.y * Sigma.y;
+ 
+  //Center Weight
+  color.xyz        *= Sigma.x;
+  //Adding to total sum of distributed weights
+  SigmaSum         += Sigma.x;
+  //Setup next weight
+  Sigma.xy         *= Sigma.yz;
+ 
+  for( int i = 0; i < LOOPCOUNT && SigmaSum < Q; ++i )
+  {
+    buffSigma.x    = Sigma.x * Sigma.y;
+	calcOffset     = pxlOffset - 1.0f + buffSigma.x / Sigma.x;
+	buffSigma.y    = Sigma.x + buffSigma.x;
+	color          += tex2D( samplerBloomH, texcoord.xy + float2( 0.0f, calcOffset*py )) * buffSigma.y;
+    color          += tex2D( samplerBloomH, texcoord.xy - float2( 0.0f, calcOffset*py )) * buffSigma.y;
+    SigmaSum       += ( 2.0f * Sigma.x + 2.0f * buffSigma.x );
+    pxlOffset      += 2.0f;
+    Sigma.xy       *= Sigma.yz;
+	Sigma.xy       *= Sigma.yz;
+  }
+ 
+  color.xyz        /= SigmaSum;
+  return float4( color.xyz, 1.0f );
+}
+
+float4 PS_Gaussian(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+{
+  float4 bloom     = tex2D( samplerBloom, texcoord );
+  float4 color     = tex2D( samplerColor, texcoord );
+  
+  if( enableBDeband == TRUE )
+  {
+    float avgdiff;
+    float maxdiff;
+    float middiff;
+    if (threshold_preset == 0)
+	{
+      avgdiff      = 0.6f;
+      maxdiff      = 1.9f;
+      middiff      = 1.2f;
+    }
+    else if (threshold_preset == 1)
+	{
+      avgdiff      = 1.8f;
+      maxdiff      = 4.0f;
+      middiff      = 2.0f;
+    }
+    else if (threshold_preset == 2)
+	{
+      avgdiff      = 3.4f;
+      maxdiff      = 6.8f;
+      middiff      = 3.3f;
+    }
+    else if (threshold_preset == 3)
+	{
+      avgdiff      = custom_avgdiff;
+      maxdiff      = custom_maxdiff;
+      middiff      = custom_middiff;
+    }
+
+    // Normalize
+    avgdiff        /= 255.0f;
+    maxdiff        /= 255.0f;
+    middiff        /= 255.0f;
+
+    // Initialize the PRNG by hashing the position + a random uniform
+    float h        = permute( permute( permute( texcoord.x ) + texcoord.y ) + drandom / 32767.0f );
+
+    float3 ref_avg; // Average of 4 reference pixels
+    float3 ref_avg_diff; // The difference between the average of 4 reference pixels and the original pixel
+    float3 ref_max_diff; // The maximum difference between one of the 4 reference pixels and the original pixel
+    float3 ref_mid_diff1; // The difference between the average of SE and NW reference pixels and the original pixel
+    float3 ref_mid_diff2; // The difference between the average of NE and SW reference pixels and the original pixel
+
+    float3 ori = bloom.xyz; // Original pixel
+    float3 res; // Final pixel
+
+    // Compute a random angle
+    float dir  = rand( permute( h )) * 6.2831853f;
+    float2 o = float2( cos( dir ), sin( dir ));
+
+    for ( int i = 1; i <= iterations; ++i )
+	{
+      // Compute a random distance
+      float dist   = rand(h) * range * i;
+      float2 pt    = dist * ReShade::PixelSize;
+
+      analyze_pixels(ori, samplerBloom, texcoord, pt, o,
+        ref_avg,
+        ref_avg_diff,
+        ref_max_diff,
+        ref_mid_diff1,
+        ref_mid_diff2);
+
+      float3 ref_avg_diff_threshold = avgdiff * i;
+      float3 ref_max_diff_threshold = maxdiff * i;
+      float3 ref_mid_diff_threshold = middiff * i;
+
+      // Fuzzy logic based pixel selection
+      float3 factor = pow(saturate(3.0 * (1.0 - ref_avg_diff  / ref_avg_diff_threshold)) *
+        saturate(3.0 * (1.0 - ref_max_diff  / ref_max_diff_threshold)) *
+        saturate(3.0 * (1.0 - ref_mid_diff1 / ref_mid_diff_threshold)) *
+        saturate(3.0 * (1.0 - ref_mid_diff2 / ref_mid_diff_threshold)), 0.1);
+
+      res          = lerp(ori, ref_avg, factor);
+      h            = permute(h);
+    }
+
+    const float dither_bit = 8.0f; //Number of bits per channel. Should be 8 for most monitors.
+
+    /*------------------------.
+    | :: Ordered Dithering :: |
+    '------------------------*/
+    //Calculate grid position
+    float grid_position = frac(dot(texcoord, (ReShade::ScreenSize * float2(1.0 / 16.0, 10.0 / 36.0)) + 0.25));
+
+    //Calculate how big the shift should be
+    float dither_shift = 0.25 * (1.0 / (pow(2, dither_bit) - 1.0));
+
+    //Shift the individual colors differently, thus making it even harder to see the dithering pattern
+    float3 dither_shift_RGB = float3(dither_shift, -dither_shift, dither_shift); //subpixel dithering
+
+    //modify shift acording to grid position.
+    dither_shift_RGB = lerp(2.0 * dither_shift_RGB, -2.0 * dither_shift_RGB, grid_position); //shift acording to grid position.
+
+    //shift the color by dither_shift
+    res += dither_shift_RGB;
+
+    bloom.xyz = res.xyz;
+  }
+ 
+  if( enableBKelvin == TRUE )
+  {
+    float3 K       = KelvinToRGB( BKelvin );
+    float3 bLum    = RGBToHCV( bloom.xyz );
+    bLum.x         = saturate( bLum.z - bLum.y * 0.5f );
+    float3 retHSL  = RGBToHSL( bloom.xyz * K.xyz );
+    bloom.xyz      = HSLToRGB( float3( retHSL.xy, bLum.x ));
+  }
+  
+  float3 bcolor    = screen( color.xyz, bloom.xyz );
+  color.xyz        = lerp( color.xyz, bcolor.xyz, BloomMix );
+  if( debugBloom == TRUE )
+    color.xyz      = bloom.xyz; //to render only bloom on screen
+  return float4( color.xyz, 1.0f );
+}
+
+float PS_PrevAvgBLuma(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+{
+  float avgLuma    = tex2D( samplerBAvgLuma, float2( 0.0f, 0.0f )).x;
+  return avgLuma;
+}
+
+//// TECHNIQUES /////////////////////////////////////////////////////////////////
+technique prod80_01_Bloom
+{
+  pass BLuma
+  {
+    VertexShader   = PostProcessVS;
+    PixelShader    = PS_WriteBLuma;
+    RenderTarget   = texBLuma;
+  }
+  pass AvgBLuma
+  {
+    VertexShader   = PostProcessVS;
+    PixelShader    = PS_AvgBLuma;
+    RenderTarget   = texBAvgLuma;
+  }
+  pass BloomIn
+  {
+    VertexShader   = PostProcessVS;
+    PixelShader    = PS_BloomIn;
+    RenderTarget   = texBloomIn;
+  }
+  pass GaussianH
+  {
+    VertexShader   = PostProcessVS;
+    PixelShader    = PS_GaussianH;
+    RenderTarget   = texBloomH;
+  }
+  pass GaussianV
+  {
+    VertexShader   = PostProcessVS;
+    PixelShader    = PS_GaussianV;
+    RenderTarget   = texBloom;
+  }
+  pass GaussianBlur
+  {
+    VertexShader   = PostProcessVS;
+    PixelShader    = PS_Gaussian;
+  }
+  pass PreviousBLuma
+  {
+    VertexShader   = PostProcessVS;
+    PixelShader    = PS_PrevAvgBLuma;
+    RenderTarget   = texBPrevAvgLuma;
+  }
+}
+
+
+

--- a/Shaders/PD80 HQ Bloom.fx
+++ b/Shaders/PD80 HQ Bloom.fx
@@ -275,14 +275,14 @@ float4 PS_GaussianH(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_T
   for( int i = 0; i < LOOPCOUNT && SigmaSum < Q; ++i )
   {
     buffSigma.x    = Sigma.x * Sigma.y;
-	calcOffset     = pxlOffset - 1.0f + buffSigma.x / Sigma.x;
-	buffSigma.y    = Sigma.x + buffSigma.x;
+	  calcOffset     = pxlOffset - 1.0f + buffSigma.x / Sigma.x;
+	  buffSigma.y    = Sigma.x + buffSigma.x;
     color          += tex2D( samplerBloomIn, texcoord.xy + float2( calcOffset*px, 0.0f )) * buffSigma.y;
     color          += tex2D( samplerBloomIn, texcoord.xy - float2( calcOffset*px, 0.0f )) * buffSigma.y;
     SigmaSum       += ( 2.0f * Sigma.x + 2.0f * buffSigma.x );
     pxlOffset      += 2.0f;
     Sigma.xy       *= Sigma.yz;
-	Sigma.xy       *= Sigma.yz;
+	  Sigma.xy       *= Sigma.yz;
   }
  
   color.xyz        /= SigmaSum;
@@ -314,14 +314,14 @@ float4 PS_GaussianV(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_T
   for( int i = 0; i < LOOPCOUNT && SigmaSum < Q; ++i )
   {
     buffSigma.x    = Sigma.x * Sigma.y;
-	calcOffset     = pxlOffset - 1.0f + buffSigma.x / Sigma.x;
-	buffSigma.y    = Sigma.x + buffSigma.x;
-	color          += tex2D( samplerBloomH, texcoord.xy + float2( 0.0f, calcOffset*py )) * buffSigma.y;
+	  calcOffset     = pxlOffset - 1.0f + buffSigma.x / Sigma.x;
+	  buffSigma.y    = Sigma.x + buffSigma.x;
+	  color          += tex2D( samplerBloomH, texcoord.xy + float2( 0.0f, calcOffset*py )) * buffSigma.y;
     color          += tex2D( samplerBloomH, texcoord.xy - float2( 0.0f, calcOffset*py )) * buffSigma.y;
     SigmaSum       += ( 2.0f * Sigma.x + 2.0f * buffSigma.x );
     pxlOffset      += 2.0f;
     Sigma.xy       *= Sigma.yz;
-	Sigma.xy       *= Sigma.yz;
+	  Sigma.xy       *= Sigma.yz;
   }
  
   color.xyz        /= SigmaSum;
@@ -339,25 +339,25 @@ float4 PS_Gaussian(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Ta
     float maxdiff;
     float middiff;
     if (threshold_preset == 0)
-	{
+	  {
       avgdiff      = 0.6f;
       maxdiff      = 1.9f;
       middiff      = 1.2f;
     }
     else if (threshold_preset == 1)
-	{
+  	{
       avgdiff      = 1.8f;
       maxdiff      = 4.0f;
       middiff      = 2.0f;
     }
     else if (threshold_preset == 2)
-	{
+    {
       avgdiff      = 3.4f;
       maxdiff      = 6.8f;
       middiff      = 3.3f;
     }
     else if (threshold_preset == 3)
-	{
+    {
       avgdiff      = custom_avgdiff;
       maxdiff      = custom_maxdiff;
       middiff      = custom_middiff;
@@ -381,11 +381,11 @@ float4 PS_Gaussian(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Ta
     float3 res; // Final pixel
 
     // Compute a random angle
-    float dir  = rand( permute( h )) * 6.2831853f;
-    float2 o = float2( cos( dir ), sin( dir ));
+    float dir      = rand( permute( h )) * 6.2831853f;
+    float2 o       = float2( cos( dir ), sin( dir ));
 
     for ( int i = 1; i <= iterations; ++i )
-	{
+	  {
       // Compute a random distance
       float dist   = rand(h) * range * i;
       float2 pt    = dist * ReShade::PixelSize;
@@ -501,6 +501,3 @@ technique prod80_01_Bloom
     RenderTarget   = texBPrevAvgLuma;
   }
 }
-
-
-

--- a/Shaders/PD80 HelperFunctions.fxh
+++ b/Shaders/PD80 HelperFunctions.fxh
@@ -1,6 +1,6 @@
 /* 
  prod80 Shaders : Helper Functions
- Required for PD80 effects
+ Version 4.0
 */
 
 #define LumCoeff float3(0.212656, 0.715158, 0.072186)

--- a/Shaders/PD80 HelperFunctions.fxh
+++ b/Shaders/PD80 HelperFunctions.fxh
@@ -1,0 +1,173 @@
+/* 
+ prod80 Shaders : Helper Functions
+ Required for PD80 effects
+*/
+
+#define LumCoeff float3(0.212656, 0.715158, 0.072186)
+#define Q 0.985f //Used for Bloom. High Quality. Other options 1.0 (not recommended), 0.99999f (no compromise), 0.8, or 0.6 (lower is less)
+#define PI 3.141592f
+#define LOOPCOUNT 150f
+
+uniform float Timer < source = "timer"; >;
+uniform int drandom < source = "random"; min = 0; max = 32767; >;
+uniform float Frametime < source = "frametime"; >;
+
+float rand( in float x )
+{
+  return frac(x / 41.0f);
+}
+
+float permute( in float x )
+{
+  return ((34.0f * x + 1.0f) * x) % 289.0f;
+}
+
+float getLuminance( in float3 x )
+{
+  return dot( x, LumCoeff );
+}
+
+float getMaxLuminance( in float3 x )
+{
+  return max( max( x.x, x.y ), x.z );
+}
+
+float Luminance( in float3 c )
+{
+  float fmin       = min( min( c.r, c.g ), c.b );
+  float fmax       = max( max( c.r, c.g ), c.b );
+  return ( fmax + fmin ) / 2.0f;
+}
+
+float3 KelvinToRGB( in float k )
+{
+  float3 ret;
+  float kelvin     = clamp( k, 1000.0f, 40000.0f ) / 100.0f;
+  if( kelvin <= 66.0f )
+  {
+    ret.r          = 1.0f;
+    ret.g          = saturate( 0.39008157876901960784f * log( kelvin ) - 0.63184144378862745098f );
+  }
+  else
+  {
+    float t        = kelvin - 60.0f;
+    ret.r          = saturate( 1.29293618606274509804f * pow( t, -0.1332047592f ));
+    ret.g          = saturate( 1.12989086089529411765f * pow( t, -0.0755148492f ));
+  }
+  if( kelvin >= 66.0f )
+    ret.b          = 1.0f;
+  else if( kelvin < 19.0f )
+    ret.b          = 0.0f;
+  else
+    ret.b          = saturate( 0.54320678911019607843f * log( kelvin - 10.0f ) - 1.19625408914f );
+  return ret;
+}
+
+float3 HUEToRGB( in float H )
+{
+  float R          = abs(H * 6.0f - 3.0f) - 1.0f;
+  float G          = 2.0f - abs(H * 6.0f - 2.0f);
+  float B          = 2.0f - abs(H * 6.0f - 4.0f);
+  return saturate( float3( R,G,B ));
+}
+
+float3 RGBToHCV( in float3 RGB )
+{
+  // Based on work by Sam Hocevar and Emil Persson
+  float4 P         = ( RGB.g < RGB.b ) ? float4( RGB.bg, -1.0f, 2.0f/3.0f ) : float4( RGB.gb, 0.0f, -1.0f/3.0f );
+  float4 Q1        = ( RGB.r < P.x ) ? float4( P.xyw, RGB.r ) : float4( RGB.r, P.yzx );
+  float C          = Q1.x - min( Q1.w, Q1.y );
+  float H          = abs(( Q1.w - Q1.y ) / ( 6 * C + 0.000001f ) + Q1.z );
+  return float3( H, C, Q1.x );
+}
+
+float3 RGBToHSL( in float3 RGB )
+{
+  RGB.xyz          = max( RGB.xyz, 0.000001f );
+  float3 HCV       = RGBToHCV(RGB);
+  float L          = HCV.z - HCV.y * 0.5f;
+  float S          = HCV.y / ( 1.0f - abs( L * 2.0f - 1.0f ) + 0.000001f);
+  return float3( HCV.x, S, L );
+}
+
+float3 HSLToRGB( in float3 HSL )
+{
+  float3 RGB       = HUEToRGB(HSL.x);
+  float C          = (1.0f - abs(2.0f * HSL.z - 1)) * HSL.y;
+  return ( RGB - 0.5f ) * C + HSL.z;
+}
+
+float3 LinearTosRGB( in float3 color )
+{
+  float3 x         = color * 12.92f;
+  float3 y         = 1.055f * pow( saturate( color ), 1.0f / 2.4f ) - 0.055f;
+  float3 clr       = color;
+  clr.r            = color.r < 0.0031308f ? x.r : y.r;
+  clr.g            = color.g < 0.0031308f ? x.g : y.g;
+  clr.b            = color.b < 0.0031308f ? x.b : y.b;
+  return clr;
+}
+
+float3 SRGBToLinear( in float3 color )
+{
+  float3 x         = color / 12.92f;
+  float3 y         = pow( max(( color + 0.055f ) / 1.055f, 0.0f ), 2.4f );
+  float3 clr       = color;
+  clr.r            = color.r <= 0.04045f ? x.r : y.r;
+  clr.g            = color.g <= 0.04045f ? x.g : y.g;
+  clr.b            = color.b <= 0.04045f ? x.b : y.b;
+  return clr;
+}
+
+float Log2Exposure( in float avgLuminance, in float GreyValue )
+{
+  float exposure   = 0.0f;
+  avgLuminance     = max(avgLuminance, 0.000001f);
+  // GreyValue should be 0.148 based on https://placeholderart.wordpress.com/2014/11/21/implementing-a-physically-based-camera-manual-exposure/
+  // But more success using higher values >= 0.5
+  float linExp     = GreyValue / avgLuminance;
+  exposure         = log2( linExp );
+  return exposure;
+}
+
+float3 CalcExposedColor( in float3 color, in float avgLuminance, in float offset, in float GreyValue )
+{
+  float exposure   = Log2Exposure( avgLuminance, GreyValue );
+  exposure         += offset; //offset = exposure
+  return exp2( exposure ) * color;
+}
+
+float3 Filmic( in float3 Fc, in float FA, in float FB, in float FC, in float FD, in float FE, in float FF, in float FWhite )
+{
+  float3 num       = (( Fc * ( FA * Fc + FC * FB ) + FD * FE ) / ( Fc * ( FA * Fc + FB ) + FD * FF )) - FE / FF;
+  float3 denom     = (( FWhite * ( FA * FWhite + FC * FB ) + FD * FE ) / ( FWhite * ( FA * FWhite + FB ) + FD * FF )) - FE / FF;
+  return LinearTosRGB( num / denom );
+}
+
+float3 BlendLuma( in float3 base, in float3 blend )
+{
+  float3 HSLBase   = RGBToHSL( base );
+  float3 HSLBlend  = RGBToHSL( blend );
+  return HSLToRGB( float3( HSLBase.x, HSLBase.y, HSLBlend.z ));
+}
+
+float3 screen( in float3 c, in float3 b )
+{ 
+  return 1.0f - ( 1.0f - c ) * ( 1.0f - b );
+}
+
+float3 softlight( in float3 c, in float3 b )
+{
+  return b < 0.5f ? ( 2.0f * c * b + c * c * ( 1.0f - 2.0f * b )) : ( sqrt( c ) * ( 2.0f * b - 1.0f ) + 2.0f * c * ( 1.0f - b ));
+}
+
+float3 overlay( in float3 c, in float3 b )
+{
+  return c < 0.5f ? 2.0f * c * b : ( 1.0f - 2.0f * ( 1.0f - c ) * ( 1.0f - b ));
+}
+
+float smootherstep( in float edge0, in float edge1, in float x )
+{
+   x               = clamp(( x - edge0 ) / ( edge1 - edge0 ), 0.0f, 1.0f );
+   return x * x * x * ( x * ( x * 6.0f - 15.0f ) + 10.0f );
+}

--- a/Shaders/PD80 Sharpening.fx
+++ b/Shaders/PD80 Sharpening.fx
@@ -1,0 +1,180 @@
+/* 
+ Luma Sharpening by prod80 for ReShade
+ Version 3.0
+*/
+
+#include "ReShade.fxh"
+#include "ReShadeUI.fxh"
+#include "PD80 HelperFunctions.fxh"
+
+//// UI ELEMENTS ////////////////////////////////////////////////////////////////
+uniform bool enableShowEdges <
+  ui_label = "Show only Sharpening Texture";
+  ui_category = "Sharpening";
+  > = false;
+
+uniform float BlurSigma <
+  ui_label = "Sharpening Width";
+  ui_category = "Sharpening";
+  ui_type = "slider";
+  ui_min = 0.3;
+  ui_max = 2.0;
+  > = 0.45;
+  
+uniform float Sharpening <
+  ui_label = "Sharpening Strength";
+  ui_category = "Sharpening";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 5.0;
+  > = 1.7;
+  
+uniform float Threshold <
+  ui_label = "Sharpening Threshold";
+  ui_category = "Sharpening";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 1.0;
+  > = 0.0;
+  
+uniform float limiter <
+  ui_label = "Sharpening Highlight Limiter";
+  ui_category = "Sharpening";
+  ui_type = "slider";
+  ui_min = 0.0;
+  ui_max = 1.0;
+  > = 0.03;
+
+//// TEXTURES ///////////////////////////////////////////////////////////////////
+texture texColorBuffer : COLOR;
+texture texDepthBuffer : DEPTH;
+texture texGaussianH { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; }; 
+texture texGaussian { Width = BUFFER_WIDTH; Height = BUFFER_HEIGHT; };
+
+//// SAMPLERS ///////////////////////////////////////////////////////////////////
+sampler samplerColor { Texture = texColorBuffer; };
+sampler samplerDepth { Texture = texDepthBuffer; };
+sampler samplerGaussianH { Texture = texGaussianH; };
+sampler samplerGaussian { Texture = texGaussian; };
+
+//// DEFINES ////////////////////////////////////////////////////////////////////
+//See PD80 HelperFunctions.fxh
+
+//// BUFFERS ////////////////////////////////////////////////////////////////////
+// Not supported in ReShade (?)
+
+//// FUNCTIONS //////////////////////////////////////////////////////////////////
+//See PD80 HelperFunctions.fxh
+
+//// COMPUTE SHADERS ////////////////////////////////////////////////////////////
+// Not supported in ReShade (?)
+
+//// PIXEL SHADERS //////////////////////////////////////////////////////////////
+
+float4 PS_GaussianH(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+{
+  float4 color     = tex2D( samplerColor, texcoord );
+  float px         = 1.0f / BUFFER_WIDTH;
+  float SigmaSum   = 0.0f;
+  float pxlOffset  = 1.0f;
+ 
+  //Gaussian Math
+  float3 Sigma;
+  Sigma.x          = 1.0f / ( sqrt( 2.0f * PI ) * BlurSigma );
+  Sigma.y          = exp( -0.5f / ( BlurSigma * BlurSigma ));
+  Sigma.z          = Sigma.y * Sigma.y;
+ 
+  //Center Weight
+  color.xyz        *= Sigma.x;
+  //Adding to total sum of distributed weights
+  SigmaSum         += Sigma.x;
+  //Setup next weight
+  Sigma.xy         *= Sigma.yz;
+ 
+  for( int i = 0; i < 7; ++i )
+  {
+    color          += tex2D( samplerColor, texcoord.xy + float2( pxlOffset*px, 0.0f )) * Sigma.x;
+    color          += tex2D( samplerColor, texcoord.xy - float2( pxlOffset*px, 0.0f )) * Sigma.x;
+    SigmaSum       += ( 2.0f * Sigma.x );
+    pxlOffset      += 1.0f;
+    Sigma.xy       *= Sigma.yz;
+  }
+ 
+  color.xyz        /= SigmaSum;
+  return float4( color.xyz, 1.0f );
+}
+
+float4 PS_GaussianV(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+{
+  float4 color     = tex2D( samplerGaussianH, texcoord );
+  float py         = 1.0f / BUFFER_HEIGHT;
+  float SigmaSum   = 0.0f;
+  float pxlOffset  = 1.0f;
+ 
+  //Gaussian Math
+  float3 Sigma;
+  Sigma.x          = 1.0f / ( sqrt( 2.0f * PI ) * BlurSigma );
+  Sigma.y          = exp( -0.5f / ( BlurSigma * BlurSigma ));
+  Sigma.z          = Sigma.y * Sigma.y;
+ 
+  //Center Weight
+  color.xyz        *= Sigma.x;
+  //Adding to total sum of distributed weights
+  SigmaSum         += Sigma.x;
+  //Setup next weight
+  Sigma.xy         *= Sigma.yz;
+ 
+  for( int i = 0; i < 7; ++i )
+  {
+    color          += tex2D( samplerGaussianH, texcoord.xy + float2( 0.0f, pxlOffset*py )) * Sigma.x;
+    color          += tex2D( samplerGaussianH, texcoord.xy - float2( 0.0f, pxlOffset*py )) * Sigma.x;
+    SigmaSum       += ( 2.0f * Sigma.x );
+    pxlOffset      += 1.0f;
+    Sigma.xy       *= Sigma.yz;
+  }
+ 
+  color.xyz        /= SigmaSum;
+  return float4( color.xyz, 1.0f );
+}
+
+float4 PS_LumaSharpen(float4 pos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
+{
+  float4 orig      = tex2D( samplerColor, texcoord );
+  float4 gaussian  = tex2D( samplerGaussian, texcoord );
+  float3 edges     = max( saturate( orig.xyz - gaussian.xyz ) - Threshold, 0.0f );
+  float3 invGauss  = saturate( 1.0f - gaussian.xyz );
+  float3 oInvGauss = saturate( orig.xyz + invGauss.xyz );
+  float3 invOGauss = max( saturate( 1.0f - oInvGauss.xyz ) - Threshold, 0.0f );
+  edges            = max(( saturate( Sharpening * edges.xyz )) - ( saturate( Sharpening * invOGauss.xyz )), 0.0f );
+  float3 blend     = saturate( orig.xyz + min( edges.xyz, limiter ));
+  float3 color     = BlendLuma( orig.xyz, blend.xyz ); 
+  if( enableShowEdges == TRUE )
+    color.xyz      = min( edges.xyz, limiter );
+  
+  return float4( color.xyz, 1.0f );
+}
+
+//// TECHNIQUES /////////////////////////////////////////////////////////////////
+technique prod80_04_LumaSharpen
+{
+  pass GaussianH
+  {
+    VertexShader   = PostProcessVS;
+    PixelShader    = PS_GaussianH;
+    RenderTarget   = texGaussianH;
+  }
+  pass GaussianV
+  {
+    VertexShader   = PostProcessVS;
+    PixelShader    = PS_GaussianV;
+    RenderTarget   = texGaussian;
+  }
+  pass LumaSharpen
+  {
+    VertexShader   = PostProcessVS;
+    PixelShader    = PS_LumaSharpen;
+  }
+}
+
+
+

--- a/Shaders/PD80 Sharpening.fx
+++ b/Shaders/PD80 Sharpening.fx
@@ -1,6 +1,6 @@
 /* 
  Luma Sharpening by prod80 for ReShade
- Version 3.0
+ Version 4.0
 */
 
 #include "ReShade.fxh"

--- a/Shaders/PD80 Sharpening.fx
+++ b/Shaders/PD80 Sharpening.fx
@@ -175,6 +175,3 @@ technique prod80_04_LumaSharpen
     PixelShader    = PS_LumaSharpen;
   }
 }
-
-
-


### PR DESCRIPTION
B&W Shader with various options to create the image
- Selection of color to create B&W
- Controls of Levels, Contrast, Brightness
- Options to blend with Gaussian blurred self, self, selectable color gradient, original colored image (can select multiple options to blend them all together)
- Blending options; darken, multiply, linearburn, colorburn, lighten, screen, colordodge, lineardodge, overlay, softlight, vividlight, linearlight, pinlight
- Chromatic Aberration filter with rotation option and ofsset based on distance to middle
- Film Grain/Noise filter based on 3D Perlin noise filter