### PR TITLE
Reshade.fxh Emulator Changes

### DIFF
--- a/Shaders/ReShade.fxh
+++ b/Shaders/ReShade.fxh
@@ -28,12 +28,12 @@
 	#define RESHADE_DEPTH_INPUT_X_SCALE 1
 #endif
 //the Offset value to add to the Y, Positive numbers = Up, Negative numbers = Down
-#ifndef RESHADE_DEPTH_INPUT_Y_OFFSET_SCALE
-	#define RESHADE_DEPTH_INPUT_Y_OFFSET_SCALE 0
+#ifndef RESHADE_DEPTH_INPUT_Y_OFFSET
+	#define RESHADE_DEPTH_INPUT_Y_OFFSET 0
 #endif
 //the Offset value to add to the X, Positive numbers = Right, Negative numbers = Left
-#ifndef RESHADE_DEPTH_INPUT_X_OFFSET_SCALE
-	#define RESHADE_DEPTH_INPUT_X_OFFSET_SCALE 0
+#ifndef RESHADE_DEPTH_INPUT_X_OFFSET
+	#define RESHADE_DEPTH_INPUT_X_OFFSET 0
 #endif
 
 namespace ReShade
@@ -66,9 +66,9 @@ namespace ReShade
 		texcoord.y = 1.0 - texcoord.y;
 #endif
 		texcoord.x /= RESHADE_DEPTH_INPUT_X_SCALE; //above 1 expands, below 1 contracts
-    	texcoord.y /= RESHADE_DEPTH_INPUT_Y_SCALE; //above 1 expands, below 1 contracts
-		texcoord.x -= (RESHADE_DEPTH_INPUT_X_OFFSET_SCALE/2.000000001); //halves the input value before applying
-    	texcoord.y += (RESHADE_DEPTH_INPUT_Y_OFFSET_SCALE/2.000000001); //halves the input value before applying, adds instead of minusing
+		texcoord.y /= RESHADE_DEPTH_INPUT_Y_SCALE; //above 1 expands, below 1 contracts
+		texcoord.x -= (RESHADE_DEPTH_INPUT_X_OFFSET/2.000000001); //halves the input value before applying
+		texcoord.y += (RESHADE_DEPTH_INPUT_Y_OFFSET/2.000000001); //halves the input value before applying, adds instead of minusing
 		float depth = tex2Dlod(DepthBuffer, float4(texcoord, 0, 0)).x * RESHADE_DEPTH_MULTIPLIER; //RESHADE_DEPTH_MULTIPLER only useful for emulators, keep at 1 for standard operation
 
 #if RESHADE_DEPTH_INPUT_IS_LOGARITHMIC

--- a/Shaders/ReShade.fxh
+++ b/Shaders/ReShade.fxh
@@ -16,6 +16,29 @@
 #ifndef RESHADE_DEPTH_LINEARIZATION_FAR_PLANE
 	#define RESHADE_DEPTH_LINEARIZATION_FAR_PLANE 1000.0
 #endif
+// Reserved for Emulators with Weak Depth Buffers
+// Keep at 1 for Stock Behaviour
+#ifndef RESHADE_DEPTH_MULTIPLIER
+	#define RESHADE_DEPTH_MULTIPLIER 1
+#endif
+// Depth Scale Factors Per Axis.
+//  Keep at 1 for Stock Behaviour.
+// Below 1 Expands and Above 1 Contracts On Relevant Axis.
+#ifndef RESHADE_DEPTH_INPUT_X_SCALE
+	#define RESHADE_DEPTH_INPUT_X_SCALE 1
+#endif
+#ifndef RESHADE_DEPTH_INPUT_Y_SCALE
+	#define RESHADE_DEPTH_INPUT_Y_SCALE 1
+#endif
+// Depth Buffer Location Offset.
+// Keep at 0 for Stock Behaviour.
+// Recommended to adjust in increments/decrements of anything between 0.005 and 0.1.
+#ifndef RESHADE_DEPTH_INPUT_X_OFFSET_SCALE
+	#define RESHADE_DEPTH_INPUT_X_OFFSET_SCALE 0
+#endif
+#ifndef RESHADE_DEPTH_INPUT_Y_OFFSET_SCALE
+	#define RESHADE_DEPTH_INPUT_Y_OFFSET_SCALE 0
+#endif
 
 namespace ReShade
 {
@@ -46,7 +69,13 @@ namespace ReShade
 #if RESHADE_DEPTH_INPUT_IS_UPSIDE_DOWN
 		texcoord.y = 1.0 - texcoord.y;
 #endif
-		float depth = tex2Dlod(DepthBuffer, float4(texcoord, 0, 0)).x;
+		// Apply the Depth Buffer Scale
+    	texcoord.y *= RESHADE_DEPTH_INPUT_Y_SCALE;
+		texcoord.x *= RESHADE_DEPTH_INPUT_X_SCALE;
+		// Apply Depth Buffer Location Offset
+    	texcoord.y -= RESHADE_DEPTH_INPUT_Y_OFFSET_SCALE;
+		texcoord.x -= RESHADE_DEPTH_INPUT_X_OFFSET_SCALE;
+		float depth = tex2Dlod(DepthBuffer, float4(texcoord, 0, 0)).x * RESHADE_DEPTH_MULTIPLIER;
 
 #if RESHADE_DEPTH_INPUT_IS_LOGARITHMIC
 		const float C = 0.01;

--- a/Shaders/ReShade.fxh
+++ b/Shaders/ReShade.fxh
@@ -22,7 +22,7 @@
 	#define RESHADE_DEPTH_MULTIPLIER 1
 #endif
 // Depth Scale Factors Per Axis.
-//  Keep at 1 for Stock Behaviour.
+// Keep at 1 for Stock Behaviour.
 // Below 1 Expands and Above 1 Contracts On Relevant Axis.
 #ifndef RESHADE_DEPTH_INPUT_X_SCALE
 	#define RESHADE_DEPTH_INPUT_X_SCALE 1
@@ -69,13 +69,25 @@ namespace ReShade
 #if RESHADE_DEPTH_INPUT_IS_UPSIDE_DOWN
 		texcoord.y = 1.0 - texcoord.y;
 #endif
-		// Apply the Depth Buffer Scale
+		// Apply the Depth Buffer Scale if modified
+#if RESHADE_DEPTH_INPUT_Y_SCALE != 0
     	texcoord.y *= RESHADE_DEPTH_INPUT_Y_SCALE;
+#endif
+#if RESHADE_DEPTH_INPUT_X_SCALE != 0
 		texcoord.x *= RESHADE_DEPTH_INPUT_X_SCALE;
-		// Apply Depth Buffer Location Offset
+#endif
+		// Apply Depth Buffer Location Offset if modified
+#if RESHADE_DEPTH_INPUT_Y_OFFSET_SCALE != 1
     	texcoord.y -= RESHADE_DEPTH_INPUT_Y_OFFSET_SCALE;
+#endif
+#if RESHADE_DEPTH_INPUT_X_OFFSET_SCALE != 1
 		texcoord.x -= RESHADE_DEPTH_INPUT_X_OFFSET_SCALE;
+#endif
+#if RESHADE_DEPTH_MULTIPLIER != 1
 		float depth = tex2Dlod(DepthBuffer, float4(texcoord, 0, 0)).x * RESHADE_DEPTH_MULTIPLIER;
+#else
+		float depth = tex2Dlod(DepthBuffer, float4(texcoord, 0, 0)).x;
+#endif
 
 #if RESHADE_DEPTH_INPUT_IS_LOGARITHMIC
 		const float C = 0.01;
@@ -94,7 +106,15 @@ namespace ReShade
 // Vertex shader generating a triangle covering the entire screen
 void PostProcessVS(in uint id : SV_VertexID, out float4 position : SV_Position, out float2 texcoord : TEXCOORD)
 {
-	texcoord.x = (id == 2) ? 2.0 : 0.0;
-	texcoord.y = (id == 1) ? 2.0 : 0.0;
+	if (id == 2)
+		texcoord.x = 2.0;
+	else
+		texcoord.x = 0.0;
+
+	if (id == 1)
+		texcoord.y = 2.0;
+	else
+		texcoord.y = 0.0;
+
 	position = float4(texcoord * float2(2.0, -2.0) + float2(-1.0, 1.0), 0.0, 1.0);
 }


### PR DESCRIPTION
Sat on resubmitting a pull request for a couple of days pending any feedback from people on discord and as such, this should be good to go for a pull.
Adds the following preprocessors:
RESHADE_DEPTH_MULTIPLIER - Useful for weak emulator buffers. Basically Bolotaur's manual tweak to reshade.fxh (https://reshade.me/forum/general-discussion/5391-release-pcsx2-with-depth-buffer-access) added in as an extra parameter that can vary per profile instead of being per reshade.fxh. When set to 1 it acts exactly the same as before the preprocessor was implemented and is set to that for compatibility by default.

RESHADE_DEPTH_INPUT_X_SCALE and RESHADE_DEPTH_INPUT_Y_SCALE - Used to scale the depth buffer output by. Below 1 shrinks the depth buffer on an axis and above 1 expands the image (2 doubling the size). By default set to 1 in order not to scale the depth buffer at all (not to break compatibility)

RESHADE_DEPTH_INPUT_X_OFFSET and RESHADE_DEPTH_INPUT_Y_OFFSET (changed _OFFSET from _OFFSET_SCALE) - Used to shift the depth buffer position on the screen. On the Y axis, Positive numbers = Up, Negative numbers = Down and on the X axis Positive numbers = Right, Negative numbers = Left. 

and thanks to crosire for suggesting the initial Y Scale in the first place on discord. I just added more after that to try and make emulator tweaking less of an ordeal in general. Though these will likely also benefit games with weird size/position depth buffers.