### PR TITLE
DisplayDepth.fx: add new settings from ReShade.fxh

### DIFF
--- a/Shaders/DisplayDepth.fx
+++ b/Shaders/DisplayDepth.fx
@@ -39,7 +39,7 @@ uniform float fUIFarPlane <
 
 uniform float fUIDepthMultiplier <
 	ui_type = "drag";
-	ui_label = "Depth Muliplier";
+	ui_label = "Depth Multiplier";
 	ui_tooltip = "RESHADE_DEPTH_MULTIPLIER=<value>";
 	ui_min = 0.0; ui_max = 1000.0;
 	ui_step = 0.001;

--- a/Shaders/DisplayDepth.fx
+++ b/Shaders/DisplayDepth.fx
@@ -37,24 +37,48 @@ uniform float fUIFarPlane <
 	ui_step = 0.1;
 > = __DISPLAYDEPTH_UI_FAR_PLANE_DEFAULT__;
 
+uniform float fUIDepthMultiplier <
+	ui_type = "drag";
+	ui_label = "Depth Muliplier";
+	ui_tooltip = "RESHADE_DEPTH_MULTIPLIER=<value>";
+	ui_min = 0.0; ui_max = 1000.0;
+	ui_step = 0.001;
+> = 1.0;
+
 uniform int iUIUpsideDown <
 	ui_type = "combo";
-	ui_label = "";
+	ui_label = "Upside Down";
 	ui_items = "RESHADE_DEPTH_INPUT_IS_UPSIDE_DOWN=0\0RESHADE_DEPTH_INPUT_IS_UPSIDE_DOWN=1\0";
 > = __DISPLAYDEPTH_UI_UPSIDE_DOWN_DEFAULT__;
 
 uniform int iUIReversed <
 	ui_type = "combo";
-	ui_label = "";
+	ui_label = "Reversed";
 	ui_items = "RESHADE_DEPTH_INPUT_IS_REVERSED=0\0RESHADE_DEPTH_INPUT_IS_REVERSED=1\0";
 > = __DISPLAYDEPTH_UI_REVERSED_DEFAULT__;
 
 uniform int iUILogarithmic <
 	ui_type = "combo";
-	ui_label = "";
+	ui_label = "Logarithmic";
 	ui_items = "RESHADE_DEPTH_INPUT_IS_LOGARITHMIC=0\0RESHADE_DEPTH_INPUT_IS_LOGARITHMIC=1\0";
 	ui_tooltip = "Change this setting if the displayed surface normals have stripes in them";
 > = __DISPLAYDEPTH_UI_LOGARITHMIC_DEFAULT__;
+
+uniform float2 fUIOffset <
+	ui_type = "drag";
+	ui_label = "Offset";
+	ui_tooltip = "Best use 'Present type'->'Depth map' and enable 'Offset' in the options below to set the offset.\nUse these values for:\nRESHADE_DEPTH_INPUT_X_OFFSET=<left value>\nRESHADE_DEPTH_INPUT_Y_OFFSET=<right value>";
+	ui_min = -1.0; ui_max = 1.0;
+	ui_step = 0.001;
+> = float2(0.0, 0.0);
+
+uniform float2 fUIScale <
+	ui_type = "drag";
+	ui_label = "Scale";
+	ui_tooltip = "Best use 'Present type'->'Depth map' and enable 'Offset' in the options below to set the scale.\nUse these values for:\nRESHADE_DEPTH_INPUT_X_SCALE=<left value>\nRESHADE_DEPTH_INPUT_Y_SCALE=<right value>";
+	ui_min = 0.0; ui_max = 2.0;
+	ui_step = 0.001;
+> = float2(1.0, 1.0);
 
 uniform int iUIPresentType <
 	ui_category = "Options";
@@ -62,6 +86,13 @@ uniform int iUIPresentType <
 	ui_label = "Present type";
 	ui_items = "Depth map\0Normal map\0Show both (Vertical 50/50)\0";
 > = 2;
+
+uniform bool bUIShowOffset <
+	ui_category = "Options";
+	ui_type = "radio";
+	ui_tooltip = "Blend depth output with backbuffer";
+	ui_label = "Show Offset";
+> = false;
 
 float GetDepth(float2 texcoord)
 {
@@ -78,7 +109,11 @@ float GetDepth(float2 texcoord)
 		texcoord.y = 1.0 - texcoord.y;
 	}
 
-	float depth = tex2Dlod(ReShade::DepthBuffer, float4(texcoord, 0, 0)).x;
+	texcoord.x /= fUIScale.x;
+	texcoord.y /= fUIScale.y;
+	texcoord.x -= fUIOffset.x / 2.000000001;
+	texcoord.y += fUIOffset.y / 2.000000001;
+	float depth = tex2Dlod(ReShade::DepthBuffer, float4(texcoord, 0, 0)).x * fUIDepthMultiplier;
 	//RESHADE_DEPTH_INPUT_IS_LOGARITHMIC
 	if(iUILogarithmic)
 	{
@@ -111,13 +146,7 @@ float3 NormalVector(float2 texcoord)
 
 void PS_DisplayDepth(in float4 position : SV_Position, in float2 texcoord : TEXCOORD, out float3 color : SV_Target)
 {
-	float3 normal_color = NormalVector(texcoord);
-	
-	if(iUIPresentType == 1)
-	{
-		color = normal_color;
-		return;
-	}
+	float3 normal_vector = NormalVector(texcoord);
 
 	const float dither_bit = 8.0; //Number of bits per channel. Should be 8 for most monitors.
 
@@ -137,15 +166,30 @@ void PS_DisplayDepth(in float4 position : SV_Position, in float2 texcoord : TEXC
 	dither_shift_RGB = lerp(2.0 * dither_shift_RGB, -2.0 * dither_shift_RGB, grid_position); //shift acording to grid position.
 
 	//shift the color by dither_shift
-	float3 depth_color = GetDepth(texcoord).rrr + dither_shift_RGB;
+	float3 depth_value = GetDepth(texcoord).rrr + dither_shift_RGB;
 
-	if(iUIPresentType == 0)
+	float3 normal_and_depth = lerp(normal_vector, depth_value, step(BUFFER_WIDTH * 0.5, position.x));
+
+	color = depth_value;
+
+	if(iUIPresentType == 1)
 	{
-		color = depth_color;
+		color = normal_vector;
+	}
+	if(iUIPresentType == 2)
+	{
+		color = normal_and_depth;
+	}
+
+	if(bUIShowOffset)
+	{
+		float3 backbuffer = tex2D(ReShade::BackBuffer, texcoord).rgb;
+
+		//Blend depth_value and backbuffer with 'overlay' so the offset is more noticeable
+		color = lerp(2*color*backbuffer, 1.0 - 2.0 * (1.0 - color) * (1.0 - backbuffer), max(color.r, max(color.g, color.b)) < 0.5 ? 0.0 : 1.0 );
+
 		return;
 	}
-	
-	color = lerp(normal_color, depth_color, step(BUFFER_WIDTH * 0.5, position.x));
 }
 
 technique DisplayDepth <


### PR DESCRIPTION
Like the other settings from ReShade.fxh the correct offset and scale can now be checked in real-time.
It is possible to blend the depth output with the backbuffer so figuring out the offset is easier.
Also added labels to uniforms and rearragned PS_DisplayDepth a bit.