### PR TITLE
Add dither toggle to AmbientLight.fx

### DIFF
--- a/Shaders/AmbientLight.fx
+++ b/Shaders/AmbientLight.fx
@@ -408,8 +408,12 @@ float4 PS_AL_Magic(float4 vpos : SV_Position, float2 texcoord : TEXCOORD) : SV_T
 		high += highLens;
 	}
 
-	float dither = 0.15 * (1.0 / (pow(2, 10.0) - 1.0));
-	dither = lerp(2.0 * dither, -2.0 * dither, frac(dot(texcoord, BUFFER_SCREEN_SIZE * float2(1.0 / 16.0, 10.0 / 36.0)) + 0.25));
+	float dither = 0.0;
+	if (AL_Dither)
+	{
+		dither = 0.15 * (1.0 / (pow(2, 10.0) - 1.0));
+		dither = lerp(2.0 * dither, -2.0 * dither, frac(dot(texcoord, BUFFER_SCREEN_SIZE * float2(1.0 / 16.0, 10.0 / 36.0)) + 0.25));
+	}
 
 	if (all(base.xyz == 1.0))
 	{
@@ -420,7 +424,7 @@ float4 PS_AL_Magic(float4 vpos : SV_Position, float2 texcoord : TEXCOORD) : SV_T
 	[flatten]
 #endif
 
-	if (AL_Adaptation && AL_Dither)
+	if (AL_Adaptation)
 	{
 		base.xyz *= max(0.0f, (1.0f - adapt * 0.75f * alAdaptBaseMult * pow(abs(1.0f - (base.x + base.y + base.z) / 3), alAdaptBaseBlackLvL)));
 		float4 highSampleMix = (1.0 - ((1.0 - base) * (1.0 - high * 1.0))) + dither;
@@ -428,28 +432,13 @@ float4 PS_AL_Magic(float4 vpos : SV_Position, float2 texcoord : TEXCOORD) : SV_T
 		float baseSampleMix = baseSample.r + baseSample.g + baseSample.b;
 		return baseSampleMix > 0.008 ? baseSample : lerp(base, highSampleMix, max(0.0f, (alInt - adapt) * 0.85f) * baseSampleMix);
 	}
-  else if (AL_Adaptation)
-	{
-		base.xyz *= max(0.0f, (1.0f - adapt * 0.75f * alAdaptBaseMult * pow(abs(1.0f - (base.x + base.y + base.z) / 3), alAdaptBaseBlackLvL)));
-		float4 highSampleMix = (1.0 - ((1.0 - base) * (1.0 - high * 1.0)));
-		float4 baseSample = lerp(base, highSampleMix, max(0.0f, alInt - adapt));
-		float baseSampleMix = baseSample.r + baseSample.g + baseSample.b;
-		return baseSampleMix > 0.008 ? baseSample : lerp(base, highSampleMix, max(0.0f, (alInt - adapt) * 0.85f) * baseSampleMix);
-	}
-	else if (AL_Dither)
+	else
 	{
 		float4 highSampleMix = (1.0 - ((1.0 - base) * (1.0 - high * 1.0))) + dither + adapt;
 		float4 baseSample = lerp(base, highSampleMix, alInt);
 		float baseSampleMix = baseSample.r + baseSample.g + baseSample.b;
 		return baseSampleMix > 0.008 ? baseSample : lerp(base, highSampleMix, max(0.0f, alInt * 0.85f) * baseSampleMix);
 	}
-	else
-  {
-    float4 highSampleMix = (1.0 - ((1.0 - base) * (1.0 - high * 1.0))) + adapt;
-    float4 baseSample = lerp(base, highSampleMix, alInt);
-    float baseSampleMix = baseSample.r + baseSample.g + baseSample.b;
-    return baseSampleMix > 0.008 ? baseSample : lerp(base, highSampleMix, max(0.0f, alInt * 0.85f) * baseSampleMix);
-  }
 }
 
 technique AmbientLight


### PR DESCRIPTION
An updated version of Ganossa's AmbientLight.fx with a toggle to disable dithering and eliminate a pattern of diagonal lines generated by it.

Originally posted by SoZ on the Reshade forums and corrected by me:
[https://reshade.me/forum/shader-presentation/3029-ambientlight-fx-with-dither-toggle#21222](url)