### PR TITLE
Updated Several Shaders to Reduce Calc's but Keep Functionality

### DIFF
--- a/Shaders/3DFX.fx
+++ b/Shaders/3DFX.fx
@@ -2,6 +2,24 @@
 ////**3DFX**////
 //----------////
 
+// !!! adding comments about what this shader seems to do
+/*
+	Seems to be trying to emulate 4x1 linear filter from
+	3DFX Voodoo graphics cards. I think the original shader
+	code is here...
+
+	http://leileilol.mancubus.net/shaders/
+
+	Shader is a mixed bag. Seems to just create thin scanlines
+	on a increased gamma image. On 3D FPS games (eg: Daggerfall
+	Unity) it creates artifacts of outlines of things at certain
+	viewing angles. EG: looking at a column, it will create lines
+	that twist around the column, or looking at a tree line it
+	will create an inverse outline of the tree line at the bottom
+	of the screen. So, not sure if this is doing what was intended.
+	Or, it might be best for 2D.
+*/
+
 #include "ReShade.fxh"
 #include "ReShadeUI.fxh"
 
@@ -54,6 +72,15 @@ float fmod(float a, float b)
   return (a < 0) ? -c : c;   /* if ( a < 0 ) c = 0-c */
 }
 
+// !!! making overloaded float2 version
+// !!! to do per-component math on parts
+// !!! below doing fmod to x & y
+float2 fmod(float2 a, float2 b)
+{
+  float2 c = frac(abs(a/b)) * abs(b);
+  return (a < 0) ? -c : c;   /* if ( a < 0 ) c = 0-c */
+}
+
 float4 PS_3DFX(float4 vpos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
 {
 	float4 colorInput = tex2D(ReShade::BackBuffer, texcoord);
@@ -62,30 +89,54 @@ float4 PS_3DFX(float4 vpos : SV_Position, float2 texcoord : TEXCOORD) : SV_Targe
 	
 	float2 ditheu = texcoord.xy * res.xy;
 
-	ditheu.x = texcoord.x * res.x;
-	ditheu.y = texcoord.y * res.y;
+	// !!! already set this when declared variable
+//	ditheu.x = texcoord.x * res.x;
+//	ditheu.y = texcoord.y * res.y;
 
 	// Dither. Total rewrite.
 	// NOW, WHAT PIXEL AM I!??
 
-	int ditx = int(fmod(ditheu.x, 4.0));
-	int dity = int(fmod(ditheu.y, 4.0));
-	int ditdex = ditx * 4 + dity; // 4x4!
-	float3 color;
-	float3 colord;
-	color.r = colorInput.r * 255;
-	color.g = colorInput.g * 255;
-	color.b = colorInput.b * 255;
-	int yeh = 0;
+//	int ditx = int(fmod(ditheu.x, 4.0));
+//	int dity = int(fmod(ditheu.y, 4.0));
+//	int ditdex = ditx * 4 + dity; // 4x4!
+
+	// !!! re-doing this using float2 fmod()
+	int2 dit = int2(fmod(ditheu.xy, 4.0));
+	int ditdex = dit.x * 4 + dit.y; // 4x4!
+
+//	float3 color;
+//	float3 colord;
+//	color.r = colorInput.r * 255;
+//	color.g = colorInput.g * 255;
+//	color.b = colorInput.b * 255;
+
+	// !!! can create var & set it with per-component math
+	float3 color = colorInput.rgb * 255.0;
+
+//	int yeh = 0;	// !!! no longer needed, b/c nuked if/else
 	int ohyes = 0;
 
-    float erroredtable[16] = {
+	/*
+	// original
+	float erroredtable[16] = {
 	16,4,13,1,   
 	8,12,5,9,
 	14,2,15,3,
 	6,10,7,11		
-    };
+	};
+	*/
 	
+	// !!! adding const recommender
+	// !!! spacing values to look nicer
+	const float erroredtable[16] = {
+			16,  4, 13,  1,   
+			 8, 12,  5,  9,
+			14,  2, 15,  3,
+			 6, 10,  7, 11		
+		};
+
+	/*
+	// original
 	// looping through a lookup table matrix
 	//for (yeh=ditdex; yeh<(ditdex+16); yeh++) ohyes = pow(erroredtable[yeh-15], 0.72f);
 	// Unfortunately, RetroArch doesn't support loops so I have to unroll this. =(
@@ -107,21 +158,59 @@ float4 PS_3DFX(float4 vpos : SV_Position, float2 texcoord : TEXCOORD) : SV_Targe
 	else if (yeh++==ditdex) ohyes = erroredtable[13];
 	else if (yeh++==ditdex) ohyes = erroredtable[14];
 	else if (yeh++==ditdex) ohyes = erroredtable[15];
+	*/
+	
+	// !!! not sure what he's trying to accomplish up above
+	// !!! he's looping through to see...
+	// !!!      if 0 = 0 .. pick value[0]
+	// !!! else if 1 = 1 .. pick value[1]
+	// !!! etc
+	// !!! it makes no sense and just wastes processing.
+	// !!! just pick the value at ditdex, and get
+	// !!! on with life.
+	// !!! also, he says to pow(value, 0.72f)
+	// !!! but doesn't do that.. so I guess the
+	// !!! errordtable values are already pow'ed?
+
+	ohyes = erroredtable[ditdex];
+
+	// !!! experimenting with doing the pow'ing suggested
+	// !!! in original shader comments above to see what happens
+	// !!! after messing around, doesn't seem to make a difference
+//	ohyes = pow( ohyes, 0.72f);
+
 
 	// Adjust the dither thing
-	ohyes = 17 - (ohyes - 1); // invert
-	ohyes *= DITHERAMOUNT;
-	ohyes += DITHERBIAS;
+//	ohyes = 17 - (ohyes - 1); // invert
+//	ohyes *= DITHERAMOUNT;
+//	ohyes += DITHERBIAS;
 
-	colord.r = color.r + ohyes;
-	colord.g = color.g + (ohyes / 2);
-	colord.b = color.b + ohyes;
+	// !!! again, not sure why he coded like
+	// !!! above, but can just pre-subtract
+	// !!! the 17 & 1
+	ohyes = 16 - ohyes; // invert
+
+	// !!! this might MAD better
+	ohyes = ohyes * DITHERAMOUNT + DITHERBIAS;
+
+//	colord.r = color.r + ohyes;
+//	colord.g = color.g + (ohyes / 2);
+//	colord.b = color.b + ohyes;
+
+	// !!! moving var declaration down to where it's being worked with
+	// !!! also altering declaration to streamline with per-component math
+	float3 colord = color;
+	colord.rb += ohyes;
+	colord.g += (ohyes / 2);
+
 	colorInput.rgb = colord.rgb * 0.003921568627451; // divide by 255, i don't trust em
 
 	//
 	// Reduce to 16-bit color
 	//
 
+	/*
+	// original
 	float why = 1;
 	float3 reduceme = 1;
 	float radooct = 32;	// 32 is usually the proper value
@@ -143,32 +232,77 @@ float4 PS_3DFX(float4 vpos : SV_Position, float2 texcoord : TEXCOORD) : SV_Targe
 	reduceme.b = float(floor(reduceme.b));	
 	reduceme.b /= radooct; 
 	reduceme.b = pow(reduceme.b, why);
+	*/
+	
+	// !!! re-doing this with per-component math
+//	float why = 1;
+	float3 reduceme = colorInput.rgb;		// !!! can just set this to colorInput.rgb at start
+	const float radooct = 32;	// 32 is usually the proper value // !!! making const
+
+//	reduceme = pow(reduceme, why);  		// !!! why = 1, so this is pointless
+	reduceme *= radooct;
+	reduceme = floor(reduceme);			// !!! shouldn't have to convert floor's output to float
+	reduceme /= radooct; 
+//	reduceme.r = pow(reduceme.r, why);		// !!! why = 1, so this is pointless
+	
+
 
 	colorInput.rgb = reduceme.rgb;
 
+	// !!! removed braces around this.. not necessary
+	// !!! un-tabbed contents one step
+
 	// Add the purple line of lineness here, so the filter process catches it and gets gammaed.
-	{
-		float leifx_linegamma = (LEIFX_LINES / 10);
-		float horzline1 = 	(fmod(ditheu.y, 2.0));
-		if (horzline1 < 1)	leifx_linegamma = 0;
-	
-		colorInput.r += leifx_linegamma;
-		colorInput.g += leifx_linegamma;
-		colorInput.b += leifx_linegamma;	
-	}
+//	{
+
+//	float leifx_linegamma = (LEIFX_LINES / 10);
+//	float horzline1 = 	(fmod(ditheu.y, 2.0));
+//	if (horzline1 < 1)	leifx_linegamma = 0;
+
+	// !!! re-arranging this
+	float leifx_linegamma;
+	float horzline1 = 	fmod(ditheu.y, 2.0);	// !!! removed unnecessary parenthesis
+
+	// !!! converting this to if/else
+	// !!! b/c no sense in calc'ing leifx_linegamma above
+	// !!! if we might just make it 0 here, so calc it here
+	if (horzline1 < 1)
+		leifx_linegamma = 0;
+	else
+		leifx_linegamma = LEIFX_LINES / 10;	// !!! removed unnecessary parenthesis
+
+//	colorInput.r += leifx_linegamma;
+//	colorInput.g += leifx_linegamma;
+//	colorInput.b += leifx_linegamma;	
+
+	// !!! can do all this with per-component math
+	colorInput.rgb += leifx_linegamma;
+//	}
 
    return colorInput;
 }
 
 float4 PS_3DFX1(float4 vpos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
 {
-   float4 colorInput = tex2D(ReShade::BackBuffer, texcoord);
-   float2 pixel = BUFFER_PIXEL_SIZE;
+	float4 colorInput = tex2D(ReShade::BackBuffer, texcoord);
 
-	float3 pixel1 = tex2D(ReShade::BackBuffer, texcoord + float2((pixel.x), 0)).rgb;
-	float3 pixel2 = tex2D(ReShade::BackBuffer, texcoord + float2(-pixel.x, 0)).rgb;
-	float3 pixelblend;
+//	float2 pixel = BUFFER_PIXEL_SIZE;
+//	float3 pixel1 = tex2D(ReShade::BackBuffer, texcoord + float2((pixel.x), 0)).rgb;
+//	float3 pixel2 = tex2D(ReShade::BackBuffer, texcoord + float2(-pixel.x, 0)).rgb;
+//	float3 pixelblend; // !!! not used
 
+	// !!! making cleaner offsets
+	// !!! and getting rid of pointless +0 math
+	// !!! (P)ositive, (N)egative
+	float2 texcoordP = texcoord;
+	float2 texcoordN = texcoord;
+	texcoordP.x += BUFFER_PIXEL_SIZE.x;
+	texcoordN.x -= BUFFER_PIXEL_SIZE.x;
+	float3 pixel1 = tex2D(ReShade::BackBuffer, texcoordP).rgb;
+	float3 pixel2 = tex2D(ReShade::BackBuffer, texcoordN).rgb;
+
+	/*
+	// original
 	// New filter
 	{
 		float3 pixeldiff;
@@ -199,23 +333,43 @@ float4 PS_3DFX1(float4 vpos : SV_Position, float2 texcoord : TEXCOORD) : SV_Targ
 		pixelmake.rgb = (pixeldiff.rgb / 4) + (pixeldiffleft.rgb / 16);
 		colorInput.rgb = (colorInput.rgb + pixelmake.rgb);
 	}	
+	*/
+	
+	// !!! removed pointless braces
+	// !!! un-tabbled contents up a step
+	float3 pixeldiff = pixel2.rgb - colorInput.rgb;
+	float3 pixeldiffleft = pixel1.rgb - colorInput.rgb;
+
+	// !!! all the if statements were just
+	// !!! over-engineered clamp / saturation
+	float3 rangemax = float3( FILTCAP, FILTCAPG, FILTCAP );
+	float3 rangemin = -rangemax;
+
+	pixeldiff = clamp( pixeldiff, rangemin, rangemax );
+	pixeldiffleft = clamp( pixeldiffleft, rangemin, rangemax );
+
+	float3 pixelmake = (pixeldiff / 4) + (pixeldiffleft / 16);
+	colorInput.rgb += pixelmake.rgb;
 
 	return colorInput;
 }
 
 float4 PS_3DFX2(float4 vpos : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
 {
-   float4 colorInput = tex2D(ReShade::BackBuffer, texcoord);
+	float4 colorInput = tex2D(ReShade::BackBuffer, texcoord);
 
 	// Gamma scanlines
 	// the Voodoo drivers usually supply a 1.3 gamma setting whether people liked it or not
 	// but it was enough to brainwash the competition for looking 'too dark'
 
-	colorInput.r = pow(abs(colorInput.r), 1.0 / GAMMA_LEVEL);
-	colorInput.g = pow(abs(colorInput.g), 1.0 / GAMMA_LEVEL);
-	colorInput.b = pow(abs(colorInput.b), 1.0 / GAMMA_LEVEL);
+//	colorInput.r = pow(abs(colorInput.r), 1.0 / GAMMA_LEVEL);
+//	colorInput.g = pow(abs(colorInput.g), 1.0 / GAMMA_LEVEL);
+//	colorInput.b = pow(abs(colorInput.b), 1.0 / GAMMA_LEVEL);
 
-   return colorInput;
+	// !!! can do this all in one shot with per-component math
+	colorInput.rgb = pow(abs(colorInput.rgb), 1.0 / GAMMA_LEVEL);
+
+	return colorInput;
 }
 
 technique LeiFx_Tech

--- a/Shaders/ASCII.fx
+++ b/Shaders/ASCII.fx
@@ -156,276 +156,360 @@ uniform float framecount < source = "framecount"; >;
 | :: Effect :: |
 '-------------*/
 
+// modified - Craig - Jul 8th, 2020
+// !!! indented AsciiPass contents,
+// !!! b/c hard to tell where func started / ended
+
 float3 AsciiPass( float2 tex )
 {
+	/*-------------------------.
+	| :: Sample and average :: |
+	'-------------------------*/
 
-/*-------------------------.
-| :: Sample and average :: |
-'-------------------------*/
+	//if (Ascii_font != 1)
+	float2 Ascii_font_size = float2(3.0,5.0); //3x5
+	float num_of_chars = 14. ; 
 
-//if (Ascii_font != 1)
-float2 Ascii_font_size = float2(3.0,5.0); //3x5
-float num_of_chars = 14. ; 
+	if (Ascii_font == 1)
+	{
+		Ascii_font_size = float2(5.0,5.0); //5x5
+		num_of_chars = 17.; 
+	}
 
-if (Ascii_font == 1)
-{
-	Ascii_font_size = float2(5.0,5.0); //5x5
-	num_of_chars = 17.; 
-}
+	float quant = 1.0/(num_of_chars-1.0); //value used for quantization 
 
-float quant = 1.0/(num_of_chars-1.0); //value used for quantization 
+	float2 Ascii_block = Ascii_font_size + float(Ascii_spacing);
+	float2 cursor_position = trunc((BUFFER_SCREEN_SIZE / Ascii_block) * tex) * (Ascii_block / BUFFER_SCREEN_SIZE);
 
-float2 Ascii_block = Ascii_font_size + float(Ascii_spacing);
-float2 cursor_position = trunc((BUFFER_SCREEN_SIZE / Ascii_block) * tex) * (Ascii_block / BUFFER_SCREEN_SIZE);
+	/*
+	//TODO Cleanup - and maybe find a better/faster pattern - possibly blur the pixels first with a 2 pass aproach
+	//-- Pattern 2 - Sample ALL the pixels! --
+	float3 color = tex2D(asciiSampler, cursor_position + float2( 1.5, 1.5) * BUFFER_PIXEL_SIZE).rgb;
+	color += tex2D(asciiSampler, cursor_position + float2( 1.5, 3.5) * BUFFER_PIXEL_SIZE).rgb;
+	color += tex2D(asciiSampler, cursor_position + float2( 1.5, 5.5) * BUFFER_PIXEL_SIZE).rgb;
+	//color += tex2D(asciiSampler, cursor_position + float2( 0.5, 6.5) * BUFFER_PIXEL_SIZE).rgb;
+	color += tex2D(asciiSampler, cursor_position + float2( 3.5, 1.5) * BUFFER_PIXEL_SIZE).rgb;
+	color += tex2D(asciiSampler, cursor_position + float2( 3.5, 3.5) * BUFFER_PIXEL_SIZE).rgb;
+	color += tex2D(asciiSampler, cursor_position + float2( 3.5, 5.5) * BUFFER_PIXEL_SIZE).rgb;
+	//color += tex2D(asciiSampler, cursor_position + float2( 2.5, 6.5) * BUFFER_PIXEL_SIZE).rgb;
+	color += tex2D(asciiSampler, cursor_position + float2( 5.5, 1.5) * BUFFER_PIXEL_SIZE).rgb;
+	color += tex2D(asciiSampler, cursor_position + float2( 5.5, 3.5) * BUFFER_PIXEL_SIZE).rgb;
+	color += tex2D(asciiSampler, cursor_position + float2( 5.5, 5.5) * BUFFER_PIXEL_SIZE).rgb;
+	//color += tex2D(asciiSampler, cursor_position + float2( 4.5, 6.5) * BUFFER_PIXEL_SIZE).rgb;
+	//color += tex2D(asciiSampler, cursor_position + float2( 6.5, 0.5) * BUFFER_PIXEL_SIZE).rgb;
+	//color += tex2D(asciiSampler, cursor_position + float2( 6.5, 2.5) * BUFFER_PIXEL_SIZE).rgb;
+	//color += tex2D(asciiSampler, cursor_position + float2( 6.5, 4.5) * BUFFER_PIXEL_SIZE).rgb;
+	//color += tex2D(asciiSampler, cursor_position + float2( 6.5, 6.5) * BUFFER_PIXEL_SIZE).rgb;
 
+	color /= 9.0;
+	*/
+	
+	// !!! cleaned it up a bit by pre-calc'ing texcoords/offsets.
+	// !!! updated the commented-out code, too, just in case
+	// !!! someone else comes along and wants to fiddle with it
 
-//TODO Cleanup - and maybe find a better/faster pattern - possibly blur the pixels first with a 2 pass aproach
-//-- Pattern 2 - Sample ALL the pixels! --
-float3 color = tex2D(asciiSampler, cursor_position + float2( 1.5, 1.5) * BUFFER_PIXEL_SIZE).rgb;
-color += tex2D(asciiSampler, cursor_position + float2( 1.5, 3.5) * BUFFER_PIXEL_SIZE).rgb;
-color += tex2D(asciiSampler, cursor_position + float2( 1.5, 5.5) * BUFFER_PIXEL_SIZE).rgb;
-//color += tex2D(asciiSampler, cursor_position + float2( 0.5, 6.5) * BUFFER_PIXEL_SIZE).rgb;
-color += tex2D(asciiSampler, cursor_position + float2( 3.5, 1.5) * BUFFER_PIXEL_SIZE).rgb;
-color += tex2D(asciiSampler, cursor_position + float2( 3.5, 3.5) * BUFFER_PIXEL_SIZE).rgb;
-color += tex2D(asciiSampler, cursor_position + float2( 3.5, 5.5) * BUFFER_PIXEL_SIZE).rgb;
-//color += tex2D(asciiSampler, cursor_position + float2( 2.5, 6.5) * BUFFER_PIXEL_SIZE).rgb;
-color += tex2D(asciiSampler, cursor_position + float2( 5.5, 1.5) * BUFFER_PIXEL_SIZE).rgb;
-color += tex2D(asciiSampler, cursor_position + float2( 5.5, 3.5) * BUFFER_PIXEL_SIZE).rgb;
-color += tex2D(asciiSampler, cursor_position + float2( 5.5, 5.5) * BUFFER_PIXEL_SIZE).rgb;
-//color += tex2D(asciiSampler, cursor_position + float2( 4.5, 6.5) * BUFFER_PIXEL_SIZE).rgb;
-//color += tex2D(asciiSampler, cursor_position + float2( 6.5, 0.5) * BUFFER_PIXEL_SIZE).rgb;
-//color += tex2D(asciiSampler, cursor_position + float2( 6.5, 2.5) * BUFFER_PIXEL_SIZE).rgb;
-//color += tex2D(asciiSampler, cursor_position + float2( 6.5, 4.5) * BUFFER_PIXEL_SIZE).rgb;
-//color += tex2D(asciiSampler, cursor_position + float2( 6.5, 6.5) * BUFFER_PIXEL_SIZE).rgb;
+//	float2 cp05 = cursor_position + BUFFER_PIXEL_SIZE * 0.5;
+	float2 cp15 = cursor_position + BUFFER_PIXEL_SIZE * 1.5;
+//	float2 cp25 = cursor_position + BUFFER_PIXEL_SIZE * 2.5;
+	float2 cp35 = cursor_position + BUFFER_PIXEL_SIZE * 3.5;
+//	float2 cp45 = cursor_position + BUFFER_PIXEL_SIZE * 4.5;
+	float2 cp55 = cursor_position + BUFFER_PIXEL_SIZE * 5.5;
+//	float2 cp65 = cursor_position + BUFFER_PIXEL_SIZE * 6.5;
 
-color /= 9.0;
+	float3 color;
+	color  = tex2D(asciiSampler, float2( cp15.x, cp15.y )).rgb;
+	color += tex2D(asciiSampler, float2( cp15.x, cp35.y )).rgb;
+	color += tex2D(asciiSampler, float2( cp15.x, cp55.y )).rgb;
+//	color += tex2D(asciiSampler, float2( cp05.x, cp65.y )).rgb;
+	color += tex2D(asciiSampler, float2( cp35.x, cp15.y )).rgb;
+	color += tex2D(asciiSampler, float2( cp35.x, cp35.y )).rgb;
+	color += tex2D(asciiSampler, float2( cp35.x, cp55.y )).rgb;
+//	color += tex2D(asciiSampler, float2( cp25.x, cp65.y )).rgb;
+	color += tex2D(asciiSampler, float2( cp55.x, cp15.y )).rgb;
+	color += tex2D(asciiSampler, float2( cp55.x, cp35.y )).rgb;
+	color += tex2D(asciiSampler, float2( cp55.x, cp55.y )).rgb;
+//	color += tex2D(asciiSampler, float2( cp45.x, cp65.y )).rgb;
+//	color += tex2D(asciiSampler, float2( cp65.x, cp05.y )).rgb;
+//	color += tex2D(asciiSampler, float2( cp65.x, cp25.y )).rgb;
+//	color += tex2D(asciiSampler, float2( cp65.x, cp45.y )).rgb;
+//	color += tex2D(asciiSampler, float2( cp65.x, cp65.y )).rgb;
 
-/*	
-//-- Pattern 3 - Just one -- 
-float3 color = tex2D(asciiSampler, cursor_position + float2(4.0,4.0) * BUFFER_PIXEL_SIZE)	.rgb; //this may be fast but it's not very temporally stable
-*/
+	// !!! this is avg'ing the color, so if you uncomment
+	// !!! extra lines above, you'll need to modify the divisor
+	color /= 9.0;
+	
+	
 
-/*------------------------.
-| :: Make it grayscale :: |
-'------------------------*/
-
-float luma = dot(color,float3(0.2126, 0.7152, 0.0722));
-
-float gray = luma;
-
-if (Ascii_invert_brightness)
-	gray = 1.0 - gray;
-
-
-/*----------------.
-| :: Debugging :: |
-'----------------*/
-
-if (Ascii_dithering_debug_gradient)
-{
-	//gray = sqrt(dot(float2((cursor_position.x - 0.5)*1.778,cursor_position.y - 0.5),float2((cursor_position.x - 0.5)*1.778,cursor_position.y - 0.5))) * 1.1;
-	//gray = (cursor_position.x + cursor_position.y) * 0.5; //diagonal test gradient
-	//gray = smoothstep(0.0,1.0,gray); //increase contrast
-	gray = cursor_position.x; //horizontal test gradient
-	//gray = cursor_position.y; //vertical test gradient
-}
-/*-------------------.
-| :: Get position :: |
-'-------------------*/
-
-float2 p = frac((BUFFER_SCREEN_SIZE / Ascii_block) * tex);  //p is the position of the current pixel inside the character
-
-p = trunc(p * Ascii_block);
-//p = trunc(p * Ascii_block - float2(1.5,1.5)) ;
-
-float x = (Ascii_font_size.x * p.y + p.x); //x is the number of the position in the bitfield
-  
-/*----------------.
-| :: Dithering :: |
-'----------------*/
-
-//TODO : Try make an ordered dither rather than the random dither. Random looks a bit too noisy for my taste.	
-
-if (Ascii_dithering != 0)
-{
-//Pseudo Random Number Generator
-// -- PRNG 1 - Reference --
-float seed = dot(cursor_position, float2(12.9898,78.233)); //I could add more salt here if I wanted to
-float sine = sin(seed); //cos also works well. Sincos too if you want 2D noise.
-float noise = frac(sine * 43758.5453 + cursor_position.y);
-
-float dither_shift = (quant * Ascii_dithering_intensity); // Using noise to determine shift.
-
-float dither_shift_half = (dither_shift * 0.5); // The noise should vary between +- 0.5
-dither_shift = dither_shift * noise - dither_shift_half; // MAD
-
-//shift the color by dither_shift
-gray += dither_shift; //apply dithering
-}
-
-/*---------------------------.
-| :: Convert to character :: |
-'---------------------------*/
-
-float n = 0;
-
-if (Ascii_font == 1)
-{	
-	// -- 5x5 bitmap font by CeeJay.dk --
-	// .:^"~cvo*wSO8Q0#
-
-	//17 characters including space which is handled as a special case
-
-	//The serial aproach to this would take 16 cycles, so I instead used an upside down binary tree to parallelize this to only 5 cycles
-
-	float n12   = (gray < (2. * quant))  ? 4194304.  : 131200.  ; // . or :
-	float n34   = (gray < (4. * quant))  ? 324.      : 330.     ; // ^ or "
-	float n56   = (gray < (6. * quant))  ? 283712.   : 12650880.; // ~ or c
-	float n78   = (gray < (8. * quant))  ? 4532768.  : 13191552.; // v or o
-	float n910  = (gray < (10. * quant)) ? 10648704. : 11195936.; // * or w
-	float n1112 = (gray < (12. * quant)) ? 15218734. : 15255086.; // S or O
-	float n1314 = (gray < (14. * quant)) ? 15252014. : 32294446.; // 8 or Q
-	float n1516 = (gray < (16. * quant)) ? 15324974. : 11512810.; // 0 or #
-
-	float n1234     = (gray < (3. * quant))  ? n12   : n34;
-	float n5678     = (gray < (7. * quant))  ? n56   : n78;
-	float n9101112  = (gray < (11. * quant)) ? n910  : n1112;
-	float n13141516 = (gray < (15. * quant)) ? n1314 : n1516;
-
-	float n12345678 = (gray < (5. * quant)) ? n1234 : n5678;
-	float n910111213141516 = (gray < (13. * quant)) ? n9101112 : n13141516;
-
-	n = (gray < (9. * quant)) ? n12345678 : n910111213141516;
-}
-else // Ascii_font == 0 , the 3x5 font
-{
-	// -- 3x5 bitmap font by CeeJay.dk --
-	// .:;s*oSOXH0
-
-	//14 characters including space which is handled as a special case
-
-	/* Font reference :
-
-	//The plusses are "likes". I was rating how much I liked that character over other alternatives.
-
-	3  ^ 42.
-	3  - 448.
-	3  i (short) 9232.
-	3  ; 5136. ++
-	4  " 45.
-	4  i 9346.
-	4  s 5200. ++
-	5  + 1488.
-	5  * 2728. ++
-	6  c 25200.
-	6  o 11088. ++
-	7  v 11112.
-	7  S 14478. ++
-	8  O 11114. ++
-	9  F 5071.
-	9  5 (rounded) 14543.
-	9  X 23213. ++
-	10 A 23530.
-	10 D 15211. +
-	11 H 23533. +
-	11 5 (square) 31183.
-	11 2 (square) 29671. ++
-
-	5 (rounded) 14543.
+	/*	
+	//-- Pattern 3 - Just one -- 
+	float3 color = tex2D(asciiSampler, cursor_position + float2(4.0,4.0) * BUFFER_PIXEL_SIZE)	.rgb; //this may be fast but it's not very temporally stable
 	*/
 
-	float n12   = (gray < (2. * quant))  ? 4096.	: 1040.	; // . or :
-	float n34   = (gray < (4. * quant))  ? 5136.	: 5200.	; // ; or s
-	float n56   = (gray < (6. * quant))  ? 2728.	: 11088.; // * or o
-	float n78   = (gray < (8. * quant))  ? 14478.	: 11114.; // S or O
-	float n910  = (gray < (10. * quant)) ? 23213.	: 15211.; // X or D
-	float n1112 = (gray < (12. * quant)) ? 23533.	: 31599.; // H or 0
-	float n13 = 31727.; // 8
+	/*------------------------.
+	| :: Make it grayscale :: |
+	'------------------------*/
 
-	float n1234     = (gray < (3. * quant))  ? n12		: n34;
-	float n5678     = (gray < (7. * quant))  ? n56		: n78;
-	float n9101112  = (gray < (11. * quant)) ? n910	: n1112;
+	float luma = dot(color,float3(0.2126, 0.7152, 0.0722));
 
-	float n12345678 =  (gray < (5. * quant))	? n1234		: n5678;
-	float n910111213 = (gray < (13. * quant))	? n9101112	: n13;
+	float gray = luma;
 
-	n = (gray < (9. * quant)) ? n12345678 : n910111213;
-}
+	if (Ascii_invert_brightness)
+		gray = 1.0 - gray;
 
 
-/*--------------------------------.
-| :: Decode character bitfield :: |
-'--------------------------------*/
+	/*----------------.
+	| :: Debugging :: |
+	'----------------*/
 
-float character = 0.0;
-
-//Test values
-//n = -(exp2(24.)-1.0); //-(2^24-1) All bits set - a white 5x5 box
-
-float lit = (gray <= (1. * quant))	//If black then set all pixels to black (the space character)
-	? 0.0								//That way I don't have to use a character bitfield for space
-	: 1.0 ;								//I simply let it to decode to the second darkest "." and turn its pixels off
-
-float signbit = (n < 0.0) //is n negative? (I would like to test for negative 0 here too but can't)
-	? lit
-	: 0.0 ;
-
-signbit = (x > 23.5)	//is this the first pixel in the character?
-	? signbit			//if so set to the signbit (which may be on or off depending on if the number was negative)
-	: 0.0 ;				//else make it black
-
-//Tenary Multiply exp2
-character = ( frac( abs( n*exp2(-x-1.0))) >= 0.5) ? lit : signbit; 	//If the bit for the right position is set, then light up the pixel
-																	//UNLESS gray was dark enough, then keep the pixel dark to make a space
-																	//If the bit for the right position was not set, then turn off the pixel
-																	//UNLESS it's the first pixel in the character AND n is negative - if so light up the pixel.
-																	//This way I can use all 24 bits in the mantissa as well as the signbit for characters.
-
-if (clamp(p.x, 0.0, Ascii_font_size.x - 1.0) != p.x || clamp(p.y, 0.0, Ascii_font_size.y - 1.0) != p.y) //Is this the space around the character?
-	character = 0.0; 																					//If so make the pixel black.
-
-
-/*---------------.
-| :: Colorize :: |
-'---------------*/
-
-if (Ascii_swap_colors)
-{
-	if (Ascii_font_color_mode  == 2)
+	if (Ascii_dithering_debug_gradient)
 	{
-		color = (character) ? character * color : Ascii_font_color;
+		//gray = sqrt(dot(float2((cursor_position.x - 0.5)*1.778,cursor_position.y - 0.5),float2((cursor_position.x - 0.5)*1.778,cursor_position.y - 0.5))) * 1.1;
+		//gray = (cursor_position.x + cursor_position.y) * 0.5; //diagonal test gradient
+		//gray = smoothstep(0.0,1.0,gray); //increase contrast
+		gray = cursor_position.x; //horizontal test gradient
+		//gray = cursor_position.y; //vertical test gradient
 	}
-	else if (Ascii_font_color_mode  == 1)
-	{
-		color = (character) ? Ascii_background_color * gray : Ascii_font_color;	
-	}
-	else // Ascii_font_color_mode == 0
-	{ 
-		color = (character) ? Ascii_background_color : Ascii_font_color;
-	}
-}
-else
-{
-	if (Ascii_font_color_mode  == 2)
-	{
-		color = (character) ? character * color : Ascii_background_color;
-	}
-	else if (Ascii_font_color_mode  == 1)
-	{
-		color = (character) ? Ascii_font_color * gray : Ascii_background_color;
-	}
-	else // Ascii_font_color_mode == 0
-	{
-		color = (character) ? Ascii_font_color : Ascii_background_color;
-	}
-}
+	/*-------------------.
+	| :: Get position :: |
+	'-------------------*/
 
-/*-------------.
-| :: Return :: |
-'-------------*/
+	float2 p = frac((BUFFER_SCREEN_SIZE / Ascii_block) * tex);  //p is the position of the current pixel inside the character
 
-//color = gray;
-return saturate(color);
+	p = trunc(p * Ascii_block);
+	//p = trunc(p * Ascii_block - float2(1.5,1.5)) ;
+
+	float x = (Ascii_font_size.x * p.y + p.x); //x is the number of the position in the bitfield
+
+	/*----------------.
+	| :: Dithering :: |
+	'----------------*/
+
+	//TODO : Try make an ordered dither rather than the random dither. Random looks a bit too noisy for my taste.	
+
+	if (Ascii_dithering != 0)
+	{
+	//Pseudo Random Number Generator
+	// -- PRNG 1 - Reference --
+	float seed = dot(cursor_position, float2(12.9898,78.233)); //I could add more salt here if I wanted to
+	float sine = sin(seed); //cos also works well. Sincos too if you want 2D noise.
+	float noise = frac(sine * 43758.5453 + cursor_position.y);
+
+	float dither_shift = (quant * Ascii_dithering_intensity); // Using noise to determine shift.
+
+	float dither_shift_half = (dither_shift * 0.5); // The noise should vary between +- 0.5
+	dither_shift = dither_shift * noise - dither_shift_half; // MAD
+
+	//shift the color by dither_shift
+	gray += dither_shift; //apply dithering
+	}
+
+	/*---------------------------.
+	| :: Convert to character :: |
+	'---------------------------*/
+
+	float n = 0;
+
+	if (Ascii_font == 1)
+	{	
+		// -- 5x5 bitmap font by CeeJay.dk --
+		// .:^"~cvo*wSO8Q0#
+
+		//17 characters including space which is handled as a special case
+
+		//The serial aproach to this would take 16 cycles, so I instead used an upside down binary tree to parallelize this to only 5 cycles
+		/*
+		// original
+		float n12   = (gray < (2. * quant))  ? 4194304.  : 131200.  ; // . or :
+		float n34   = (gray < (4. * quant))  ? 324.      : 330.     ; // ^ or "
+		float n56   = (gray < (6. * quant))  ? 283712.   : 12650880.; // ~ or c
+		float n78   = (gray < (8. * quant))  ? 4532768.  : 13191552.; // v or o
+		float n910  = (gray < (10. * quant)) ? 10648704. : 11195936.; // * or w
+		float n1112 = (gray < (12. * quant)) ? 15218734. : 15255086.; // S or O
+		float n1314 = (gray < (14. * quant)) ? 15252014. : 32294446.; // 8 or Q
+		float n1516 = (gray < (16. * quant)) ? 15324974. : 11512810.; // 0 or #
+
+		float n1234     = (gray < (3. * quant))  ? n12   : n34;
+		float n5678     = (gray < (7. * quant))  ? n56   : n78;
+		float n9101112  = (gray < (11. * quant)) ? n910  : n1112;
+		float n13141516 = (gray < (15. * quant)) ? n1314 : n1516;
+
+		float n12345678 = (gray < (5. * quant)) ? n1234 : n5678;
+		float n910111213141516 = (gray < (13. * quant)) ? n9101112 : n13141516;
+
+		n = (gray < (9. * quant)) ? n12345678 : n910111213141516;
+		*/
+		
+		// !!! modified var names to organize a bit
+		float	n0	= (gray < (2.  * quant)) ? 4194304.  : 131200.  ; // . or :
+		float	n1	= (gray < (4.  * quant)) ? 324.      : 330.     ; // ^ or "
+		float	n2	= (gray < (6.  * quant)) ? 283712.   : 12650880.; // ~ or c
+		float	n3	= (gray < (8.  * quant)) ? 4532768.  : 13191552.; // v or o
+		float	n4	= (gray < (10. * quant)) ? 10648704. : 11195936.; // * or w
+		float	n5	= (gray < (12. * quant)) ? 15218734. : 15255086.; // S or O
+		float	n6	= (gray < (14. * quant)) ? 15252014. : 32294446.; // 8 or Q
+		float	n7	= (gray < (16. * quant)) ? 15324974. : 11512810.; // 0 or #
+
+			n0	= (gray < (3.  * quant)) ? n0 : n1;
+			n2	= (gray < (7.  * quant)) ? n2 : n3;
+			n4	= (gray < (11. * quant)) ? n4 : n5;
+			n6	= (gray < (15. * quant)) ? n6 : n7;
+
+			n0	= (gray < (5.  * quant)) ? n0 : n2;
+			n4	= (gray < (13. * quant)) ? n4 : n6;
+
+			n	= (gray < (9.  * quant)) ? n0 : n4;
+	}
+	else // Ascii_font == 0 , the 3x5 font
+	{
+		// -- 3x5 bitmap font by CeeJay.dk --
+		// .:;s*oSOXH0
+
+		//14 characters including space which is handled as a special case
+
+		/* Font reference :
+
+		//The plusses are "likes". I was rating how much I liked that character over other alternatives.
+
+		3  ^ 42.
+		3  - 448.
+		3  i (short) 9232.
+		3  ; 5136. ++
+		4  " 45.
+		4  i 9346.
+		4  s 5200. ++
+		5  + 1488.
+		5  * 2728. ++
+		6  c 25200.
+		6  o 11088. ++
+		7  v 11112.
+		7  S 14478. ++
+		8  O 11114. ++
+		9  F 5071.
+		9  5 (rounded) 14543.
+		9  X 23213. ++
+		10 A 23530.
+		10 D 15211. +
+		11 H 23533. +
+		11 5 (square) 31183.
+		11 2 (square) 29671. ++
+
+		5 (rounded) 14543.
+		*/
+
+		/*
+		// original
+		float n12   = (gray < (2. * quant))  ? 4096.	: 1040.	; // . or :
+		float n34   = (gray < (4. * quant))  ? 5136.	: 5200.	; // ; or s
+		float n56   = (gray < (6. * quant))  ? 2728.	: 11088.; // * or o
+		float n78   = (gray < (8. * quant))  ? 14478.	: 11114.; // S or O
+		float n910  = (gray < (10. * quant)) ? 23213.	: 15211.; // X or D
+		float n1112 = (gray < (12. * quant)) ? 23533.	: 31599.; // H or 0
+		float n13 = 31727.; // 8
+
+		float n1234     = (gray < (3. * quant))  ? n12		: n34;
+		float n5678     = (gray < (7. * quant))  ? n56		: n78;
+		float n9101112  = (gray < (11. * quant)) ? n910	: n1112;
+
+		float n12345678 =  (gray < (5. * quant))	? n1234		: n5678;
+		float n910111213 = (gray < (13. * quant))	? n9101112	: n13;
+
+		n = (gray < (9. * quant)) ? n12345678 : n910111213;
+		*/
+		
+		// !!! modified var names to organize a bit
+		float	n0	= (gray < (2.  * quant)) ? 4096.	: 1040.	; // . or :
+		float	n1	= (gray < (4.  * quant)) ? 5136.	: 5200.	; // ; or s
+		float	n2	= (gray < (6.  * quant)) ? 2728.	: 11088.; // * or o
+		float	n3	= (gray < (8.  * quant)) ? 14478.	: 11114.; // S or O
+		float	n4	= (gray < (10. * quant)) ? 23213.	: 15211.; // X or D
+		float	n5 	= (gray < (12. * quant)) ? 23533.	: 31599.; // H or 0
+		float	n6	= 31727.; // 8
+
+			n0	= (gray < (3.  * quant)) ? n0 : n1;
+			n2	= (gray < (7.  * quant)) ? n2 : n3;
+			n4	= (gray < (11. * quant)) ? n4 : n5;
+
+			n0	= (gray < (5.  * quant)) ? n0 : n2;
+			n4	= (gray < (13. * quant)) ? n4 : n6;
+
+			n	= (gray < (9.  * quant)) ? n0 : n4;
+	}
+
+
+	/*--------------------------------.
+	| :: Decode character bitfield :: |
+	'--------------------------------*/
+
+	float character = 0.0;
+
+	//Test values
+	//n = -(exp2(24.)-1.0); //-(2^24-1) All bits set - a white 5x5 box
+
+	float lit = (gray <= (1. * quant))	//If black then set all pixels to black (the space character)
+		? 0.0				//That way I don't have to use a character bitfield for space
+		: 1.0 ;				//I simply let it to decode to the second darkest "." and turn its pixels off
+
+	float signbit = (n < 0.0) 		//is n negative? (I would like to test for negative 0 here too but can't)
+		? lit
+		: 0.0 ;
+
+	signbit = (x > 23.5)			//is this the first pixel in the character?
+		? signbit			//if so set to the signbit (which may be on or off depending on if the number was negative)
+		: 0.0 ;				//else make it black
+
+	//Tenary Multiply exp2
+	character = ( frac( abs( n*exp2(-x-1.0))) >= 0.5) ? lit : signbit; 	//If the bit for the right position is set, then light up the pixel
+										//This way I can use all 24 bits in the mantissa as well as the signbit for characters.
+
+	// !!! re-wrote this part to organize code a bit more
+	float2 clampP = clamp( p.xy, 0.0, Ascii_font_size.xy);
+
+	//If this is space around character, make pixel black
+	if (clampP.x != p.x || clampP.y != p.y)
+		character = 0.0;
+
+
+	/*---------------.
+	| :: Colorize :: |
+	'---------------*/
+
+	if (Ascii_swap_colors)
+	{
+		if (Ascii_font_color_mode  == 2)
+		{
+			color = (character) ? character * color : Ascii_font_color;
+		}
+		else if (Ascii_font_color_mode  == 1)
+		{
+			color = (character) ? Ascii_background_color * gray : Ascii_font_color;	
+		}
+		else // Ascii_font_color_mode == 0
+		{ 
+			color = (character) ? Ascii_background_color : Ascii_font_color;
+		}
+	}
+	else
+	{
+		if (Ascii_font_color_mode  == 2)
+		{
+			color = (character) ? character * color : Ascii_background_color;
+		}
+		else if (Ascii_font_color_mode  == 1)
+		{
+			color = (character) ? Ascii_font_color * gray : Ascii_background_color;
+		}
+		else // Ascii_font_color_mode == 0
+		{
+			color = (character) ? Ascii_font_color : Ascii_background_color;
+		}
+	}
+
+	/*-------------.
+	| :: Return :: |
+	'-------------*/
+
+	//color = gray;
+	return saturate(color);
 }
 
 

--- a/Shaders/ASCII.fx
+++ b/Shaders/ASCII.fx
@@ -171,6 +171,13 @@ uniform float framecount < source = "framecount"; >;
 // !!! fashion instead of manually writing
 // !!! out all the dot(step)s for each one.
 
+// !!! start with quant*2
+// !!! end   with quant*chararraylen
+// !!! go through each to see if value < gray (gray >= value)
+// !!! if it is, add the step 1 to index
+// !!! to generate index to pull character
+// !!! to use from char array.
+
 int charindex( float quant, float gray, int chararraylen )
 {
 	float q = quant;
@@ -182,6 +189,16 @@ int charindex( float quant, float gray, int chararraylen )
 		q += quant;
 		index += step( q, gray );
 	}
+
+	/*
+	// seems to have worse performance
+	[unroll]
+	for ( int i = 1; i <= chararraylen; i++ )
+	{
+		q = quant * i + quant;	// seems like more calc's, but maybe MAD's?
+		index += step( q, gray );
+	}
+	*/
 
 	return index;
 }

--- a/Shaders/ASCII.fx
+++ b/Shaders/ASCII.fx
@@ -339,6 +339,7 @@ float3 AsciiPass( float2 tex )
 		n = (gray < (9. * quant)) ? n12345678 : n910111213141516;
 		*/
 		
+		/*
 		// !!! modified var names to organize a bit
 		float	n0	= (gray < (2.  * quant)) ? 4194304.  : 131200.  ; // . or :
 		float	n1	= (gray < (4.  * quant)) ? 324.      : 330.     ; // ^ or "
@@ -358,6 +359,44 @@ float3 AsciiPass( float2 tex )
 			n4	= (gray < (13. * quant)) ? n4 : n6;
 
 			n	= (gray < (9.  * quant)) ? n0 : n4;
+		*/
+
+		// !!! taking it a step further, we can
+		// !!! chuck the chars into an array, then
+		// !!! use step to compare the quants to the gray
+		// !!! value, and dots to sum up the # of 1's vs. 0's we get
+		// !!! to generate an index value for the char to use.
+
+		float	chars[16];
+			chars[0]  = 4194304.0;
+			chars[1]  = 131200.00;
+			chars[2]  = 324.00000;
+			chars[3]  = 330.00000;
+			chars[4]  = 283712.00;
+			chars[5]  = 12650880.;
+			chars[6]  = 4532768.0;
+			chars[7]  = 13191552.;
+			chars[8]  = 10648704.;
+			chars[9]  = 11195936.;
+			chars[10] = 15218734.;
+			chars[11] = 15255086.;
+			chars[12] = 15252014.;
+			chars[13] = 32294446.;
+			chars[14] = 15324974.;
+			chars[15] = 11512810.;
+
+		float4	charsA = float4(  2.,  3.,  4.,  5. ) * quant;
+		float4	charsB = float4(  6.,  7.,  8.,  9. ) * quant;
+		float4	charsC = float4( 10., 11., 12., 13. ) * quant;
+		float3	charsD = float3( 14., 15., 16.)       * quant;
+
+		int	index  = dot( step( charsA, gray ), 1 );
+			index += dot( step( charsB, gray ), 1 );
+			index += dot( step( charsC, gray ), 1 );
+			index += dot( step( charsD, gray ), 1 );
+
+			n = chars[index];
+
 	}
 	else // Ascii_font == 0 , the 3x5 font
 	{
@@ -416,6 +455,7 @@ float3 AsciiPass( float2 tex )
 		n = (gray < (9. * quant)) ? n12345678 : n910111213;
 		*/
 		
+		/*
 		// !!! modified var names to organize a bit
 		float	n0	= (gray < (2.  * quant)) ? 4096.	: 1040.	; // . or :
 		float	n1	= (gray < (4.  * quant)) ? 5136.	: 5200.	; // ; or s
@@ -433,6 +473,39 @@ float3 AsciiPass( float2 tex )
 			n4	= (gray < (13. * quant)) ? n4 : n6;
 
 			n	= (gray < (9.  * quant)) ? n0 : n4;
+		*/
+
+		// !!! taking it a step further, we can
+		// !!! chuck the chars into an array, then
+		// !!! use step to compare the quants to the gray
+		// !!! value, and dots to sum up the # of 1's vs. 0's we get
+		// !!! to generate an index value for the char to use.
+
+		float	chars[13];
+			chars[0]  = 4096.0;
+			chars[1]  = 1040.0;
+			chars[2]  = 5136.0;
+			chars[3]  = 5200.0;
+			chars[4]  = 2728.0;
+			chars[5]  = 11088.;
+			chars[6]  = 14478.;
+			chars[7]  = 11114.;
+			chars[8]  = 23213.;
+			chars[9]  = 15211.;
+			chars[10] = 23533.;
+			chars[11] = 31599.;
+			chars[12] = 31727.;
+
+
+		float4	charsA = float4(  2.,  3.,  4.,  5. ) * quant;
+		float4	charsB = float4(  6.,  7.,  8.,  9. ) * quant;
+		float4	charsC = float4( 10., 11., 12., 13. ) * quant;
+
+		int	index  = dot( step( charsA, gray ), 1 );
+			index += dot( step( charsB, gray ), 1 );
+			index += dot( step( charsC, gray ), 1 );
+
+			n = chars[index];
 	}
 
 

--- a/Shaders/Bloom.fx
+++ b/Shaders/Bloom.fx
@@ -760,47 +760,53 @@ void LensFlarePass0(float4 vpos : SV_Position, float2 texcoord : TEXCOORD, out f
 	// Lenz
 	if (bLenzEnable)
 	{
+		// !!! just cleaning up values to look nicer.
+		// !!! also, the .y vals are * 3.5 in loop below,
+		// !!! but not going to pre-calc them in case the
+		// !!! 3.5 gets changed later
 		const float3 lfoffset[19] = {
-			float3(0.9, 0.01, 4),
-			float3(0.7, 0.25, 25),
-			float3(0.3, 0.25, 15),
-			float3(1, 1.0, 5),
-			float3(-0.15, 20, 1),
-			float3(-0.3, 20, 1),
-			float3(6, 6, 6),
-			float3(7, 7, 7),
-			float3(8, 8, 8),
-			float3(9, 9, 9),
-			float3(0.24, 1, 10),
-			float3(0.32, 1, 10),
-			float3(0.4, 1, 10),
-			float3(0.5, -0.5, 2),
-			float3(2, 2, -5),
-			float3(-5, 0.2, 0.2),
-			float3(20, 0.5, 0),
-			float3(0.4, 1, 10),
-			float3(0.00001, 10, 20)
+			float3( 0.90000,  0.01,  4.00),
+			float3( 0.70000,  0.25,  25.0),
+			float3( 0.30000,  0.25,  15.0),
+			float3( 1.00000,  1.00,  5.00),
+			float3(-0.15000,  20.0,  1.00),
+			float3(-0.30000,  20.0,  1.00),
+			float3( 6.00000,  6.00,  6.00),
+			float3( 7.00000,  7.00,  7.00),
+			float3( 8.00000,  8.00,  8.00),
+			float3( 9.00000,  9.00,  9.00),
+			float3( 0.24000,  1.00,  10.0),
+			float3( 0.32000,  1.00,  10.0),
+			float3( 0.40000,  1.00,  10.0),
+			float3( 0.50000, -0.50,  2.00),
+			float3( 2.00000,  2.00, -5.00),
+			float3(-5.00000,  0.20,  0.20),
+			float3( 20.0000,  0.50,  0.00),
+			float3( 0.40000,  1.00,  10.0),
+			float3( 0.00001,  10.0,  20.0)
 		};
+
+		// !!! just cleaning up values to look nicer
 		const float3 lffactors[19] = {
-			float3(1.5, 1.5, 0),
-			float3(0, 1.5, 0),
-			float3(0, 0, 1.5),
-			float3(0.2, 0.25, 0),
-			float3(0.15, 0, 0),
-			float3(0, 0, 0.15),
-			float3(1.4, 0, 0),
-			float3(1, 1, 0),
-			float3(0, 1, 0),
-			float3(0, 0, 1.4),
-			float3(1, 0.3, 0),
-			float3(1, 1, 0),
-			float3(0, 2, 4),
-			float3(0.2, 0.1, 0),
-			float3(0, 0, 1),
-			float3(1, 1, 0),
-			float3(1, 1, 0),
-			float3(0, 0, 0.2),
-			float3(0.012,0.313,0.588)
+			float3(1.500, 1.500, 0.000),
+			float3(0.000, 1.500, 0.000),
+			float3(0.000, 0.000, 1.500),
+			float3(0.200, 0.250, 0.000),
+			float3(0.150, 0.000, 0.000),
+			float3(0.000, 0.000, 0.150),
+			float3(1.400, 0.000, 0.000),
+			float3(1.000, 1.000, 0.000),
+			float3(0.000, 1.000, 0.000),
+			float3(0.000, 0.000, 1.400),
+			float3(1.000, 0.300, 0.000),
+			float3(1.000, 1.000, 0.000),
+			float3(0.000, 2.000, 4.000),
+			float3(0.200, 0.100, 0.000),
+			float3(0.000, 0.000, 1.000),
+			float3(1.000, 1.000, 0.000),
+			float3(1.000, 1.000, 0.000),
+			float3(0.000, 0.000, 0.200),
+			float3(0.012, 0.313, 0.588)
 		};
 
 		float2 lfcoord = 0;
@@ -818,8 +824,14 @@ void LensFlarePass0(float4 vpos : SV_Position, float2 texcoord : TEXCOORD, out f
 			lfcoord.xy *= lfoffset[i].z;
 			lfcoord.xy = 0.5 - lfcoord.xy;
 			float2 tempfact = (lfcoord.xy - 0.5) * 2;
-			float templensmult = clamp(1.0 - dot(tempfact, tempfact), 0, 1);
-			float3 lenstemp1 = dot(tex2Dlod(ReShade::BackBuffer, float4(lfcoord.xy, 0, 1)).rgb, 0.333);
+			
+			// replacing clamp(x,0,1) with saturate(x) just to be consistent in func usage
+//			float templensmult = clamp(1.0 - dot(tempfact, tempfact), 0, 1);
+			float templensmult = saturate(1.0 - dot(tempfact, tempfact));
+
+			// !!! making this float instead of float3
+			// !!! to cut down on unnecessary calculations
+			float lenstemp1 = dot(tex2Dlod(ReShade::BackBuffer, float4(lfcoord.xy, 0, 1)).rgb, 0.333);
 
 #if LENZ_DEPTH_CHECK
 			float templensdepth = tex2D(ReShade::DepthBuffer, lfcoord.xy).x;
@@ -827,10 +839,10 @@ void LensFlarePass0(float4 vpos : SV_Position, float2 texcoord : TEXCOORD, out f
 				lenstemp1 = 0;
 #endif
 
-			lenstemp1 = max(0, lenstemp1.xyz - fLenzThreshold);
-			lenstemp1 *= lffactors[i] * templensmult;
-
-			lenstemp += lenstemp1;
+			// !!! with it float, we can just do float - float
+			// !!! and then have lffactors (float3) * ( float * float )
+			lenstemp1 = max(0, lenstemp1 - fLenzThreshold);
+			lenstemp += lffactors[i] * ( lenstemp1 * templensmult );
 		}
 
 		lens.rgb += lenstemp * fLenzIntensity;
@@ -867,12 +879,21 @@ void LensFlarePass0(float4 vpos : SV_Position, float2 texcoord : TEXCOORD, out f
 		deltaTexCoord /= (float)iGodraySamples * fGodrayDensity;
 //		deltaTexCoord *= 1.0 / (float)iGodraySamples * fGodrayDensity;
 
-		// !!! this can get moved out of loop below,
+		// !!! all of this can get moved out of loop below,
 		// !!! b/c not impacted by g++ iterator
+
 		texcoord2 -= deltaTexCoord;
-		float4 texcoord2lod = float4(texcoord2, 0, 0);
-		float4 sample2 = tex2Dlod(ReShade::BackBuffer, texcoord2lod);
-		float sampledepth = tex2Dlod(ReShade::DepthBuffer, texcoord2lod).x;
+
+//		float4 texcoord2lod = float4(texcoord2, 0, 0);
+//		float sampledepth = tex2Dlod(ReShade::DepthBuffer, texcoord2lod).x;
+//		float4 sample2 = tex2Dlod(ReShade::BackBuffer, texcoord2lod);
+//		sample2.w = saturate(dot(sample2.xyz, 0.3333) - fGodrayThreshold);
+
+		// !!! not using LOD, so use tex2D to save processing
+		// !!! also we're calculating .w, so just pull .rgb
+		float sampledepth = tex2D(ReShade::DepthBuffer, texcoord2).x;
+		float4 sample2;
+		sample2.rgb = tex2D(ReShade::BackBuffer, texcoord2).rgb;
 		sample2.w = saturate(dot(sample2.xyz, 0.3333) - fGodrayThreshold);
 
 		// !!! mul'ing sample2.r by 1, skip
@@ -881,30 +902,18 @@ void LensFlarePass0(float4 vpos : SV_Position, float2 texcoord : TEXCOORD, out f
 		sample2.b *= 0.85;
 
 		float illuminationDecay = 1.0;
-
-
+			
 		for (int g = 0; g < iGodraySamples; g++)
 		{
-//			texcoord2 -= deltaTexCoord;
-//			float4 sample2 = tex2Dlod(ReShade::BackBuffer, texcoord2lod);
-//			float sampledepth = tex2Dlod(ReShade::DepthBuffer, texcoord2lod).x;
-//			sample2.w = saturate(dot(sample2.xyz, 0.3333) - fGodrayThreshold);
-
-			// !!! mul'ing sample2.r by 1, skip
-//			sample2.r *= 1.00;
-//			sample2.g *= 0.95;
-//			sample2.b *= 0.85;
-//			sample2 *= illuminationDecay * fGodrayWeight;
-
-			// !!! keep sample2 as-is for reference, just modify copy of it
-			float4 sample2copy = sample2 * illuminationDecay * fGodrayWeight;
+			// !!! make copy of sample2 to modify
+			// !!! float4 * ( float * float )
+			float4 sample2copy = sample2 * (illuminationDecay * fGodrayWeight);
 			
 #if GODRAY_DEPTH_CHECK == 1
 			if (sampledepth > 0.99999)
-				lens.rgb += sample2copy.xyz * sample2copy.w;
-#else
-			lens.rgb += sample2copy.xyz * sample2copy.w;
 #endif
+				lens.rgb += sample2copy.xyz * sample2copy.w;
+
 			illuminationDecay *= fGodrayDecay;
 		}
 	}
@@ -912,15 +921,22 @@ void LensFlarePass0(float4 vpos : SV_Position, float2 texcoord : TEXCOORD, out f
 	// Anamorphic flare
 	if (bAnamFlareEnable)
 	{
-		float3 anamFlare = 0;
 		const float gaussweight[5] = { 0.2270270270, 0.1945945946, 0.1216216216, 0.0540540541, 0.0162162162 };
 
-		// !!! can pre-calc this outside loop
-		float brh2 = BUFFER_RCP_HEIGHT * 2;
+		// !!! can pre-calc brh outside loop
+		float brh = BUFFER_RCP_HEIGHT * 2;
+		float2 anamCoord = texcoord.xy;
+		float3 anamSample;
+		float3 anamFlare = 0;
 
 		for (int z = -4; z < 5; z++)
 		{
-			anamFlare += GetAnamorphicSample(0, texcoord.xy + float2(0, z * brh2), fFlareBlur) * fFlareTint * gaussweight[abs(z)];
+//			anamFlare += GetAnamorphicSample(0, texcoord.xy + float2(0, z * brh), fFlareBlur) * fFlareTint * gaussweight[abs(z)];
+
+			// !!! we're only adjusting .y, so skip modifying .x
+			anamCoord.y = texcoord.y + z * brh;
+			anamSample = GetAnamorphicSample(0, anamCoord, fFlareBlur);
+			anamFlare += anamSample * fFlareTint * gaussweight[abs(z)];
 		}
 
 		lens.xyz += anamFlare * fFlareIntensity;
@@ -1050,7 +1066,7 @@ void LightingCombine(float4 vpos : SV_Position, float2 texcoord : TEXCOORD, out 
 		float lensdirtmult = dot(tex2D(SamplerBloom5, texcoord).rgb, 0.333);
 		float3 dirttex = tex2D(SamplerDirt, texcoord).rgb;
 
-		// !!! force floats to mul first before mul'ing with float3
+		// !!! float3 * ( float * float )
 		float3 lensdirt = dirttex * (lensdirtmult * fLensdirtIntensity);
 
 		lensdirt = lerp(dot(lensdirt.xyz, 0.333), lensdirt.xyz, fLensdirtSaturation);

--- a/Shaders/FakeHDR.fx
+++ b/Shaders/FakeHDR.fx
@@ -22,7 +22,8 @@ uniform float radius2 < __UNIFORM_SLIDER_FLOAT1
 > = 0.87;
 
 #include "ReShade.fxh"
-
+/*
+// original
 float3 HDRPass(float4 vpos : SV_Position, float2 texcoord : TexCoord) : SV_Target
 {
 	float3 color = tex2D(ReShade::BackBuffer, texcoord).rgb;
@@ -46,6 +47,48 @@ float3 HDRPass(float4 vpos : SV_Position, float2 texcoord : TexCoord) : SV_Targe
 	bloom_sum2 += tex2D(ReShade::BackBuffer, texcoord + float2( 0.0,  2.5) * radius2 * BUFFER_PIXEL_SIZE).rgb;
 	bloom_sum2 += tex2D(ReShade::BackBuffer, texcoord + float2(-2.5,  0.0) * radius2 * BUFFER_PIXEL_SIZE).rgb;
 	bloom_sum2 += tex2D(ReShade::BackBuffer, texcoord + float2( 2.5,  0.0) * radius2 * BUFFER_PIXEL_SIZE).rgb;
+
+	bloom_sum2 *= 0.010;
+
+	float dist = radius2 - radius1;
+	float3 HDR = (color + (bloom_sum2 - bloom_sum1)) * dist;
+	float3 blend = HDR + color;
+	color = pow(abs(blend), abs(HDRPower)) + HDR; // pow - don't use fractions for HDRpower
+	
+	return saturate(color);
+}
+*/
+
+// !!! modified - Craig - Jul 6th, 2020
+float3 HDRPass(float4 vpos : SV_Position, float2 texcoord : TexCoord) : SV_Target
+{
+	float3 color = tex2D(ReShade::BackBuffer, texcoord).rgb;
+	
+	// !!! pre-calc radius * BPS values
+	float2 rad1 = radius1 * BUFFER_PIXEL_SIZE;
+	float2 rad2 = radius2 * BUFFER_PIXEL_SIZE;
+
+	// !!! updated to use new pre-calc'ed rad value
+	float3  bloom_sum1  = tex2D(ReShade::BackBuffer, texcoord + float2( 1.5, -1.5) * rad1).rgb;
+		bloom_sum1 += tex2D(ReShade::BackBuffer, texcoord + float2(-1.5, -1.5) * rad1).rgb;
+		bloom_sum1 += tex2D(ReShade::BackBuffer, texcoord + float2( 1.5,  1.5) * rad1).rgb;
+		bloom_sum1 += tex2D(ReShade::BackBuffer, texcoord + float2(-1.5,  1.5) * rad1).rgb;
+		bloom_sum1 += tex2D(ReShade::BackBuffer, texcoord + float2( 0.0, -2.5) * rad1).rgb;
+		bloom_sum1 += tex2D(ReShade::BackBuffer, texcoord + float2( 0.0,  2.5) * rad1).rgb;
+		bloom_sum1 += tex2D(ReShade::BackBuffer, texcoord + float2(-2.5,  0.0) * rad1).rgb;
+		bloom_sum1 += tex2D(ReShade::BackBuffer, texcoord + float2( 2.5,  0.0) * rad1).rgb;
+
+	bloom_sum1 *= 0.005;
+
+	// !!! updated to use new pre-calc'ed rad value
+	float3  bloom_sum2  = tex2D(ReShade::BackBuffer, texcoord + float2( 1.5, -1.5) * rad2).rgb;
+		bloom_sum2 += tex2D(ReShade::BackBuffer, texcoord + float2(-1.5, -1.5) * rad2).rgb;
+		bloom_sum2 += tex2D(ReShade::BackBuffer, texcoord + float2( 1.5,  1.5) * rad2).rgb;
+		bloom_sum2 += tex2D(ReShade::BackBuffer, texcoord + float2(-1.5,  1.5) * rad2).rgb;
+		bloom_sum2 += tex2D(ReShade::BackBuffer, texcoord + float2( 0.0, -2.5) * rad2).rgb;	
+		bloom_sum2 += tex2D(ReShade::BackBuffer, texcoord + float2( 0.0,  2.5) * rad2).rgb;
+		bloom_sum2 += tex2D(ReShade::BackBuffer, texcoord + float2(-2.5,  0.0) * rad2).rgb;
+		bloom_sum2 += tex2D(ReShade::BackBuffer, texcoord + float2( 2.5,  0.0) * rad2).rgb;
 
 	bloom_sum2 *= 0.010;
 

--- a/Shaders/Tonemap.fx
+++ b/Shaders/Tonemap.fx
@@ -55,9 +55,16 @@ float3 TonemapPass(float4 position : SV_Position, float2 texcoord : TexCoord) : 
 	float3 mixRGB = A2 * newColor;
 	color += ((1.0f - A2) * mixRGB);
 	
+	// !!! could possibly branch this with fast_ops
+	// !!! to pre-calc 1.0/3.0 and skip calc'ing it each pass
+	// !!! and have fast_ops != 1 have it calc each pass.
 	float3 middlegray = dot(color, (1.0 / 3.0));
 	float3 diffcolor = color - middlegray;
-	color = (color + diffcolor * Saturation) / (1 + (diffcolor * Saturation)); // Saturation
+
+	// !!! can pre-calc once to use twice below
+	diffcolor *= Saturation;
+//	color = (color + diffcolor * Saturation) / (1 + (diffcolor * Saturation)); // Saturation
+	color = (color + diffcolor) / (1 + diffcolor); // Saturation
 	
 	return color;
 }


### PR DESCRIPTION
Commented out original code, and made copy with "// modified - Craig - (date)" to flag what func's I changed. Flagged the parts of the func's I changed with "// !!! (comment)" explaining what I did. Most of what I changed was procedural: just moving things out of loops that can get calc'ed once instead of over and over. End result calc should still be same, just reduced calculations getting there. The idea was to reduce calculations more, since this is a pixel / fragment shader, which can impact performance more. I experimented with the changes via Daggerfall Unity DREAM which installs ReShade shaders (Bloom.fx being one that it uses). I spent a few years tweaking shader code (did the FUEL: Reshaded mod.. didn't use Reshader.. I was manually tweaking the shaders myself). Decided to stick my nose in the shader files DREAM was using, and noticed places to tweak. Decided to just come here and see if you wanted them incorporated.