### PR TITLE
Lock UI controls behind preprocessor definition at first launch

### DIFF
--- a/Shaders/DisplayDepth.fx
+++ b/Shaders/DisplayDepth.fx
@@ -1,20 +1,21 @@
-///////////////////////////////////////////////////////
-// Ported from Reshade v2.x. Original by CeeJay.
-// Displays the depth buffer: further away is more white than close by. 
-// Use this to configure the depth buffer preprocessor settings
-// in Reshade's settings. (The RESHADE_DEPTH_INPUT_* ones)
-///////////////////////////////////////////////////////
+/*
+ * Ported from Reshade v2.x. Original by CeeJay.
+ * Visualizes the depth buffer: further away is more white than close by pixels. 
+ * Use this to configure the depth input preprocessor definitions (RESHADE_DEPTH_INPUT_*).
+ */
 
 #include "ReShade.fxh"
 
-#define __DISPLAYDEPTH_UI_FAR_PLANE_DEFAULT__ 1000.0
-#define __DISPLAYDEPTH_UI_LOGARITHMIC_DEFAULT__ 0	
-#define __DISPLAYDEPTH_UI_UPSIDE_DOWN_DEFAULT__ 0
-
-#if __RESHADE__ < 30101
+#if (__RESHADE__ < 30101) || (__RESHADE__ >= 40600)
+	#define __DISPLAYDEPTH_UI_FAR_PLANE_DEFAULT__ 1000.0
+	#define __DISPLAYDEPTH_UI_UPSIDE_DOWN_DEFAULT__ 0
 	#define __DISPLAYDEPTH_UI_REVERSED_DEFAULT__ 0
+	#define __DISPLAYDEPTH_UI_LOGARITHMIC_DEFAULT__ 0
 #else
+	#define __DISPLAYDEPTH_UI_FAR_PLANE_DEFAULT__ 1000.0
+	#define __DISPLAYDEPTH_UI_UPSIDE_DOWN_DEFAULT__ 0
 	#define __DISPLAYDEPTH_UI_REVERSED_DEFAULT__ 1
+	#define __DISPLAYDEPTH_UI_LOGARITHMIC_DEFAULT__ 0
 #endif
 
 #ifndef RESHADE_DISPLAYDEPTH_UNLOCKED
@@ -24,10 +25,10 @@
 uniform int iUIHelp <
 	ui_type = "radio";
     ui_label = " ";
-	ui_text = "This shader is helps setting up ReShade's depth buffer settings properly, so depth-depending shaders work properly.\n"
-                "All realtime controls (sliders, checkboxes...) will only affect DisplayDepth by default.\n"
+	ui_text =   "All realtime controls (sliders, checkboxes...) will only affect DisplayDepth by default.\n"
                 "To apply their settings globally, they have to be copied to the global preprocessor definitions.\n"
-                "To do this, click on 'Edit global preprocessor definitions', where 4 default entries should already be present."
+                "To guide you how to do this, you need to unlock the realtime controls of this shader with the same method.\n"
+                "Click on 'Edit global preprocessor definitions', where 4 default entries should already be present."
                 "To unlock the realtime controls, add a new entry as follows:\n\n"
                 "RESHADE_DISPLAYDEPTH_UNLOCKED       1\n\n"
                 "If done properly, various controls below will unlock. Now tweak these settings until the output looks correct, then transfer the new settings to the same place where you added the new entry.";
@@ -40,7 +41,7 @@ uniform int iUIHelp <
  #define iUIUpsideDown __DISPLAYDEPTH_UI_UPSIDE_DOWN_DEFAULT__
  #define iUIReversed __DISPLAYDEPTH_UI_REVERSED_DEFAULT__
  #define iUILogarithmic __DISPLAYDEPTH_UI_LOGARITHMIC_DEFAULT__ 
- #define fUIOffset float2(0.0, 0.0)
+ #define iUIOffset int2(0.0, 0.0)
  #define fUIScale float2(1.0, 1.0)
  #define iUIPresentType 2
  #define bUIShowOffset 0 
@@ -48,11 +49,7 @@ uniform int iUIHelp <
 
 uniform bool bUIUsePreprocessorDefs <
 	ui_label = "Use global preprocessor definitions";
-	ui_tooltip = "Enable this to override the values from\n"
-	             "'Depth Input Settings' with the\n"
-	             "preprocessor definitions. If all is set\n"
-	             "up correctly, no difference should be\n"
-	             "noticed.";
+	ui_tooltip = "Enable this to use the values set via global preprocessor definitions rather than the ones below.";
 > = false;
 
 uniform float fUIFarPlane <
@@ -66,7 +63,7 @@ uniform float fUIFarPlane <
 
 uniform float fUIDepthMultiplier <
 	ui_type = "drag";
-	ui_label = "Depth Multiplier";
+	ui_label = "Multiplier";
 	ui_tooltip = "RESHADE_DEPTH_MULTIPLIER=<value>";
 	ui_min = 0.0; ui_max = 1000.0;
 	ui_step = 0.001;
@@ -88,21 +85,22 @@ uniform int iUILogarithmic <
 	ui_type = "combo";
 	ui_label = "Logarithmic";
 	ui_items = "RESHADE_DEPTH_INPUT_IS_LOGARITHMIC=0\0RESHADE_DEPTH_INPUT_IS_LOGARITHMIC=1\0";
-	ui_tooltip = "Change this setting if the displayed surface normals have stripes in them";
+	ui_tooltip = "Change this setting if the displayed surface normals have stripes in them.";
 > = __DISPLAYDEPTH_UI_LOGARITHMIC_DEFAULT__;
 
-uniform float2 fUIOffset <
+uniform int2 iUIOffset <
 	ui_type = "drag";
 	ui_label = "Offset";
-	ui_tooltip = "Best use 'Present type'->'Depth map' and enable 'Offset' in the options below to set the offset.\nUse these values for:\nRESHADE_DEPTH_INPUT_X_OFFSET=<left value>\nRESHADE_DEPTH_INPUT_Y_OFFSET=<right value>";
-	ui_min = -1.0; ui_max = 1.0;
-	ui_step = 0.001;
-> = float2(0.0, 0.0);
+	ui_tooltip = "Best use 'Present type'->'Depth map' and enable 'Offset' in the options below to set the offset in pixels.\n"
+	             "Use these values for:\nRESHADE_DEPTH_INPUT_X_PIXEL_OFFSET=<left value>\nRESHADE_DEPTH_INPUT_Y_PIXEL_OFFSET=<right value>";
+	ui_step = 1;
+> = int2(0, 0);
 
 uniform float2 fUIScale <
 	ui_type = "drag";
 	ui_label = "Scale";
-	ui_tooltip = "Best use 'Present type'->'Depth map' and enable 'Offset' in the options below to set the scale.\nUse these values for:\nRESHADE_DEPTH_INPUT_X_SCALE=<left value>\nRESHADE_DEPTH_INPUT_Y_SCALE=<right value>";
+	ui_tooltip = "Best use 'Present type'->'Depth map' and enable 'Offset' in the options below to set the scale.\n"
+	             "Use these values for:\nRESHADE_DEPTH_INPUT_X_SCALE=<left value>\nRESHADE_DEPTH_INPUT_Y_SCALE=<right value>";
 	ui_min = 0.0; ui_max = 2.0;
 	ui_step = 0.001;
 > = float2(1.0, 1.0);
@@ -120,131 +118,101 @@ uniform bool bUIShowOffset <
 	ui_tooltip = "Blend depth output with backbuffer";
 	ui_label = "Show Offset";
 > = false;
-
 #endif
 
-float GetDepth(float2 texcoord)
+float GetLinearizedDepth(float2 texcoord)
 {
-	//Return the depth value as defined in the preprocessor definitions
-	if(bUIUsePreprocessorDefs)
+	if (bUIUsePreprocessorDefs)
 	{
 		return ReShade::GetLinearizedDepth(texcoord);
 	}
-
-	//Calculate the depth value as defined by the user
-	//RESHADE_DEPTH_INPUT_IS_UPSIDE_DOWN
-	if(iUIUpsideDown)
+	else
 	{
-		texcoord.y = 1.0 - texcoord.y;
-	}
+		// RESHADE_DEPTH_INPUT_IS_UPSIDE_DOWN
+		if (iUIUpsideDown)
+			texcoord.y = 1.0 - texcoord.y;
 
-	texcoord.x /= fUIScale.x;
-	texcoord.y /= fUIScale.y;
-	texcoord.x -= fUIOffset.x / 2.000000001;
-	texcoord.y += fUIOffset.y / 2.000000001;
-	float depth = tex2Dlod(ReShade::DepthBuffer, float4(texcoord, 0, 0)).x * fUIDepthMultiplier;
-	//RESHADE_DEPTH_INPUT_IS_LOGARITHMIC
-	if(iUILogarithmic)
-	{
+		// RESHADE_DEPTH_INPUT_X_SCALE
+		texcoord.x /= fUIScale.x;
+		// RESHADE_DEPTH_INPUT_Y_SCALE
+		texcoord.y /= fUIScale.y;
+		// RESHADE_DEPTH_INPUT_X_PIXEL_OFFSET
+		texcoord.x -= iUIOffset.x * BUFFER_RCP_WIDTH;
+		// RESHADE_DEPTH_INPUT_Y_PIXEL_OFFSET
+		texcoord.y += iUIOffset.y * BUFFER_RCP_HEIGHT;
+
+		float depth = tex2Dlod(ReShade::DepthBuffer, float4(texcoord, 0, 0)).x * fUIDepthMultiplier;
+
+		// RESHADE_DEPTH_INPUT_IS_LOGARITHMIC
 		const float C = 0.01;
-		depth = (exp(depth * log(C + 1.0)) - 1.0) / C;
-	}
-	//RESHADE_DEPTH_INPUT_IS_REVERSED
-	if(iUIReversed)
-	{
-		depth = 1.0 - depth;
-	}
+		if (iUILogarithmic)
+			depth = (exp(depth * log(C + 1.0)) - 1.0) / C;
 
-	const float N = 1.0;
-	return depth /= fUIFarPlane - depth * (fUIFarPlane - N);
+		// RESHADE_DEPTH_INPUT_IS_REVERSED
+		if (iUIReversed)
+			depth = 1.0 - depth;
+
+		const float N = 1.0;
+		depth /= fUIFarPlane - depth * (fUIFarPlane - N);
+
+		return depth;
+	}
 }
 
-float3 NormalVector(float2 texcoord)
+float3 GetScreenSpaceNormal(float2 texcoord)
 {
 	float3 offset = float3(BUFFER_PIXEL_SIZE, 0.0);
 	float2 posCenter = texcoord.xy;
 	float2 posNorth  = posCenter - offset.zy;
 	float2 posEast   = posCenter + offset.xz;
 
-	float3 vertCenter = float3(posCenter - 0.5, 1) * GetDepth(posCenter);
-	float3 vertNorth  = float3(posNorth - 0.5,  1) * GetDepth(posNorth);
-	float3 vertEast   = float3(posEast - 0.5,   1) * GetDepth(posEast);
+	float3 vertCenter = float3(posCenter - 0.5, 1) * GetLinearizedDepth(posCenter);
+	float3 vertNorth  = float3(posNorth - 0.5,  1) * GetLinearizedDepth(posNorth);
+	float3 vertEast   = float3(posEast - 0.5,   1) * GetLinearizedDepth(posEast);
 
 	return normalize(cross(vertCenter - vertNorth, vertCenter - vertEast)) * 0.5 + 0.5;
 }
 
 void PS_DisplayDepth(in float4 position : SV_Position, in float2 texcoord : TEXCOORD, out float3 color : SV_Target)
 {
-	float3 normal_vector = NormalVector(texcoord);
+	float3 depth = GetLinearizedDepth(texcoord).xxx;
+	float3 normal = GetScreenSpaceNormal(texcoord);
 
-	const float dither_bit = 8.0; //Number of bits per channel. Should be 8 for most monitors.
-
-	/*------------------------.
-	| :: Ordered Dithering :: |
-	'------------------------*/
-	//Calculate grid position
+	// Ordered dithering
+#if 1
+	const float dither_bit = 8.0; // Number of bits per channel. Should be 8 for most monitors.
+	// Calculate grid position
 	float grid_position = frac(dot(texcoord, (BUFFER_SCREEN_SIZE * float2(1.0 / 16.0, 10.0 / 36.0)) + 0.25));
-
-	//Calculate how big the shift should be
+	// Calculate how big the shift should be
 	float dither_shift = 0.25 * (1.0 / (pow(2, dither_bit) - 1.0));
+	// Shift the individual colors differently, thus making it even harder to see the dithering pattern
+	float3 dither_shift_RGB = float3(dither_shift, -dither_shift, dither_shift); // Subpixel dithering
+	// Modify shift acording to grid position.
+	dither_shift_RGB = lerp(2.0 * dither_shift_RGB, -2.0 * dither_shift_RGB, grid_position);
+	depth += dither_shift_RGB;
+#endif
 
-	//Shift the individual colors differently, thus making it even harder to see the dithering pattern
-	float3 dither_shift_RGB = float3(dither_shift, -dither_shift, dither_shift); //subpixel dithering
+	color = depth;
+	if (iUIPresentType == 1)
+		color = normal;
+	if (iUIPresentType == 2)
+		color = lerp(normal, depth, step(BUFFER_WIDTH * 0.5, position.x));
 
-	//modify shift acording to grid position.
-	dither_shift_RGB = lerp(2.0 * dither_shift_RGB, -2.0 * dither_shift_RGB, grid_position); //shift acording to grid position.
-
-	//shift the color by dither_shift
-	float3 depth_value = GetDepth(texcoord).rrr + dither_shift_RGB;
-
-	float3 normal_and_depth = lerp(normal_vector, depth_value, step(BUFFER_WIDTH * 0.5, position.x));
-
-	color = depth_value;
-
-	if(iUIPresentType == 1)
+	if (bUIShowOffset)
 	{
-		color = normal_vector;
-	}
-	if(iUIPresentType == 2)
-	{
-		color = normal_and_depth;
-	}
+		float3 color_orig = tex2D(ReShade::BackBuffer, texcoord).rgb;
 
-	if(bUIShowOffset)
-	{
-		float3 backbuffer = tex2D(ReShade::BackBuffer, texcoord).rgb;
-
-		//Blend depth_value and backbuffer with 'overlay' so the offset is more noticeable
-		color = lerp(2*color*backbuffer, 1.0 - 2.0 * (1.0 - color) * (1.0 - backbuffer), max(color.r, max(color.g, color.b)) < 0.5 ? 0.0 : 1.0 );
-
-		return;
+		// Blend depth and back buffer color with 'overlay' so the offset is more noticeable
+		color = lerp(2 * color * color_orig, 1.0 - 2.0 * (1.0 - color) * (1.0 - color_orig), max(color.r, max(color.g, color.b)) < 0.5 ? 0.0 : 1.0);
 	}
 }
 
 technique DisplayDepth <
-	ui_tooltip = "This shader helps finding the right\n"
-                 "preprocessor settings for the depth\n"
-                 "input.\n"
-                 "By default the calculated normals\n"
-                 "are shown and the goal is to make the\n"
-                 "displayed surface normals look smooth.\n"
-                 "Change the options for *_IS_REVERSED\n"
-                 "and *_IS_LOGARITHMIC in the variable editor\n"
-                 "until this happens.\n"
-                 "\n"
-                 "Change the 'Present type' to 'Depth map'\n"
-                 "and check whether close objects are dark\n"
-                 "and far away objects are white.\n"
-                 "\n"
-                 "When the right settings are found click\n"
-                 "'Edit global preprocessor definitions'\n"
-                 "(Variable editor in the 'Home' tab)\n"
-                 "and put them in there.\n"
-                 "\n"
-                 "Switching between normal map and\n"
-                 "depth map is possible via 'Present type'\n"
-                 "in the Options category.";
->
+	ui_tooltip = "This shader helps finding the right preprocessor settings for depth input.\n\n"
+                 "By default calculated normals are shown and the goal is to make the displayed surface normals look smooth.\n"
+                 "Change the options for *_IS_REVERSED and *_IS_LOGARITHMIC in the variable editor until this happens.\n"
+                 "Change the 'Present type' to 'Depth map' and check whether close objects are dark and far away objects are white.\n\n"
+                 "When the right settings are found click on 'Edit global preprocessor definitions' and put the new values there."; >
 {
 	pass
 	{

--- a/Shaders/DisplayDepth.fx
+++ b/Shaders/DisplayDepth.fx
@@ -1,26 +1,58 @@
-/*
- * Ported from Reshade v2.x. Original by CeeJay.
- * Visualizes the depth buffer: further away is more white than close by pixels. 
- * Use this to configure the depth input preprocessor definitions (RESHADE_DEPTH_INPUT_*).
- */
+///////////////////////////////////////////////////////
+// Ported from Reshade v2.x. Original by CeeJay.
+// Displays the depth buffer: further away is more white than close by. 
+// Use this to configure the depth buffer preprocessor settings
+// in Reshade's settings. (The RESHADE_DEPTH_INPUT_* ones)
+///////////////////////////////////////////////////////
 
 #include "ReShade.fxh"
 
-#if (__RESHADE__ < 30101) || (__RESHADE__ >= 40600)
-	#define __DISPLAYDEPTH_UI_FAR_PLANE_DEFAULT__ 1000.0
-	#define __DISPLAYDEPTH_UI_UPSIDE_DOWN_DEFAULT__ 0
+#define __DISPLAYDEPTH_UI_FAR_PLANE_DEFAULT__ 1000.0
+#define __DISPLAYDEPTH_UI_LOGARITHMIC_DEFAULT__ 0	
+#define __DISPLAYDEPTH_UI_UPSIDE_DOWN_DEFAULT__ 0
+
+#if __RESHADE__ < 30101
 	#define __DISPLAYDEPTH_UI_REVERSED_DEFAULT__ 0
-	#define __DISPLAYDEPTH_UI_LOGARITHMIC_DEFAULT__ 0
 #else
-	#define __DISPLAYDEPTH_UI_FAR_PLANE_DEFAULT__ 1000.0
-	#define __DISPLAYDEPTH_UI_UPSIDE_DOWN_DEFAULT__ 0
 	#define __DISPLAYDEPTH_UI_REVERSED_DEFAULT__ 1
-	#define __DISPLAYDEPTH_UI_LOGARITHMIC_DEFAULT__ 0
 #endif
+
+#ifndef RESHADE_DISPLAYDEPTH_UNLOCKED
+ #define RESHADE_DISPLAYDEPTH_UNLOCKED 0
+#endif
+
+uniform int iUIHelp <
+	ui_type = "radio";
+    ui_label = " ";
+	ui_text = "This shader is helps setting up ReShade's depth buffer settings properly, so depth-depending shaders work properly.\n"
+                "All realtime controls (sliders, checkboxes...) will only affect DisplayDepth by default.\n"
+                "To apply their settings globally, they have to be copied to the global preprocessor definitions.\n"
+                "To do this, click on 'Edit global preprocessor definitions', where 4 default entries should already be present."
+                "To unlock the realtime controls, add a new entry as follows:\n\n"
+                "RESHADE_DISPLAYDEPTH_UNLOCKED       1\n\n"
+                "If done properly, various controls below will unlock. Now tweak these settings until the output looks correct, then transfer the new settings to the same place where you added the new entry.";
+>;
+
+#if RESHADE_DISPLAYDEPTH_UNLOCKED == 0 //replace all with stubs
+ #define bUIUsePreprocessorDefs 0
+ #define fUIFarPlane __DISPLAYDEPTH_UI_FAR_PLANE_DEFAULT__
+ #define fUIDepthMultiplier 1.0
+ #define iUIUpsideDown __DISPLAYDEPTH_UI_UPSIDE_DOWN_DEFAULT__
+ #define iUIReversed __DISPLAYDEPTH_UI_REVERSED_DEFAULT__
+ #define iUILogarithmic __DISPLAYDEPTH_UI_LOGARITHMIC_DEFAULT__ 
+ #define fUIOffset float2(0.0, 0.0)
+ #define fUIScale float2(1.0, 1.0)
+ #define iUIPresentType 2
+ #define bUIShowOffset 0 
+#else
 
 uniform bool bUIUsePreprocessorDefs <
 	ui_label = "Use global preprocessor definitions";
-	ui_tooltip = "Enable this to use the values set via global preprocessor definitions rather than the ones below.";
+	ui_tooltip = "Enable this to override the values from\n"
+	             "'Depth Input Settings' with the\n"
+	             "preprocessor definitions. If all is set\n"
+	             "up correctly, no difference should be\n"
+	             "noticed.";
 > = false;
 
 uniform float fUIFarPlane <
@@ -34,7 +66,7 @@ uniform float fUIFarPlane <
 
 uniform float fUIDepthMultiplier <
 	ui_type = "drag";
-	ui_label = "Multiplier";
+	ui_label = "Depth Multiplier";
 	ui_tooltip = "RESHADE_DEPTH_MULTIPLIER=<value>";
 	ui_min = 0.0; ui_max = 1000.0;
 	ui_step = 0.001;
@@ -56,22 +88,21 @@ uniform int iUILogarithmic <
 	ui_type = "combo";
 	ui_label = "Logarithmic";
 	ui_items = "RESHADE_DEPTH_INPUT_IS_LOGARITHMIC=0\0RESHADE_DEPTH_INPUT_IS_LOGARITHMIC=1\0";
-	ui_tooltip = "Change this setting if the displayed surface normals have stripes in them.";
+	ui_tooltip = "Change this setting if the displayed surface normals have stripes in them";
 > = __DISPLAYDEPTH_UI_LOGARITHMIC_DEFAULT__;
 
-uniform int2 iUIOffset <
+uniform float2 fUIOffset <
 	ui_type = "drag";
 	ui_label = "Offset";
-	ui_tooltip = "Best use 'Present type'->'Depth map' and enable 'Offset' in the options below to set the offset in pixels.\n"
-	             "Use these values for:\nRESHADE_DEPTH_INPUT_X_PIXEL_OFFSET=<left value>\nRESHADE_DEPTH_INPUT_Y_PIXEL_OFFSET=<right value>";
-	ui_step = 1;
-> = int2(0, 0);
+	ui_tooltip = "Best use 'Present type'->'Depth map' and enable 'Offset' in the options below to set the offset.\nUse these values for:\nRESHADE_DEPTH_INPUT_X_OFFSET=<left value>\nRESHADE_DEPTH_INPUT_Y_OFFSET=<right value>";
+	ui_min = -1.0; ui_max = 1.0;
+	ui_step = 0.001;
+> = float2(0.0, 0.0);
 
 uniform float2 fUIScale <
 	ui_type = "drag";
 	ui_label = "Scale";
-	ui_tooltip = "Best use 'Present type'->'Depth map' and enable 'Offset' in the options below to set the scale.\n"
-	             "Use these values for:\nRESHADE_DEPTH_INPUT_X_SCALE=<left value>\nRESHADE_DEPTH_INPUT_Y_SCALE=<right value>";
+	ui_tooltip = "Best use 'Present type'->'Depth map' and enable 'Offset' in the options below to set the scale.\nUse these values for:\nRESHADE_DEPTH_INPUT_X_SCALE=<left value>\nRESHADE_DEPTH_INPUT_Y_SCALE=<right value>";
 	ui_min = 0.0; ui_max = 2.0;
 	ui_step = 0.001;
 > = float2(1.0, 1.0);
@@ -90,99 +121,130 @@ uniform bool bUIShowOffset <
 	ui_label = "Show Offset";
 > = false;
 
-float GetLinearizedDepth(float2 texcoord)
+#endif
+
+float GetDepth(float2 texcoord)
 {
-	if (bUIUsePreprocessorDefs)
+	//Return the depth value as defined in the preprocessor definitions
+	if(bUIUsePreprocessorDefs)
 	{
 		return ReShade::GetLinearizedDepth(texcoord);
 	}
-	else
+
+	//Calculate the depth value as defined by the user
+	//RESHADE_DEPTH_INPUT_IS_UPSIDE_DOWN
+	if(iUIUpsideDown)
 	{
-		// RESHADE_DEPTH_INPUT_IS_UPSIDE_DOWN
-		if (iUIUpsideDown)
-			texcoord.y = 1.0 - texcoord.y;
-
-		// RESHADE_DEPTH_INPUT_X_SCALE
-		texcoord.x /= fUIScale.x;
-		// RESHADE_DEPTH_INPUT_Y_SCALE
-		texcoord.y /= fUIScale.y;
-		// RESHADE_DEPTH_INPUT_X_PIXEL_OFFSET
-		texcoord.x -= iUIOffset.x * BUFFER_RCP_WIDTH;
-		// RESHADE_DEPTH_INPUT_Y_PIXEL_OFFSET
-		texcoord.y += iUIOffset.y * BUFFER_RCP_HEIGHT;
-
-		float depth = tex2Dlod(ReShade::DepthBuffer, float4(texcoord, 0, 0)).x * fUIDepthMultiplier;
-
-		// RESHADE_DEPTH_INPUT_IS_LOGARITHMIC
-		const float C = 0.01;
-		if (iUILogarithmic)
-			depth = (exp(depth * log(C + 1.0)) - 1.0) / C;
-
-		// RESHADE_DEPTH_INPUT_IS_REVERSED
-		if (iUIReversed)
-			depth = 1.0 - depth;
-
-		const float N = 1.0;
-		depth /= fUIFarPlane - depth * (fUIFarPlane - N);
-
-		return depth;
+		texcoord.y = 1.0 - texcoord.y;
 	}
+
+	texcoord.x /= fUIScale.x;
+	texcoord.y /= fUIScale.y;
+	texcoord.x -= fUIOffset.x / 2.000000001;
+	texcoord.y += fUIOffset.y / 2.000000001;
+	float depth = tex2Dlod(ReShade::DepthBuffer, float4(texcoord, 0, 0)).x * fUIDepthMultiplier;
+	//RESHADE_DEPTH_INPUT_IS_LOGARITHMIC
+	if(iUILogarithmic)
+	{
+		const float C = 0.01;
+		depth = (exp(depth * log(C + 1.0)) - 1.0) / C;
+	}
+	//RESHADE_DEPTH_INPUT_IS_REVERSED
+	if(iUIReversed)
+	{
+		depth = 1.0 - depth;
+	}
+
+	const float N = 1.0;
+	return depth /= fUIFarPlane - depth * (fUIFarPlane - N);
 }
 
-float3 GetScreenSpaceNormal(float2 texcoord)
+float3 NormalVector(float2 texcoord)
 {
 	float3 offset = float3(BUFFER_PIXEL_SIZE, 0.0);
 	float2 posCenter = texcoord.xy;
 	float2 posNorth  = posCenter - offset.zy;
 	float2 posEast   = posCenter + offset.xz;
 
-	float3 vertCenter = float3(posCenter - 0.5, 1) * GetLinearizedDepth(posCenter);
-	float3 vertNorth  = float3(posNorth - 0.5,  1) * GetLinearizedDepth(posNorth);
-	float3 vertEast   = float3(posEast - 0.5,   1) * GetLinearizedDepth(posEast);
+	float3 vertCenter = float3(posCenter - 0.5, 1) * GetDepth(posCenter);
+	float3 vertNorth  = float3(posNorth - 0.5,  1) * GetDepth(posNorth);
+	float3 vertEast   = float3(posEast - 0.5,   1) * GetDepth(posEast);
 
 	return normalize(cross(vertCenter - vertNorth, vertCenter - vertEast)) * 0.5 + 0.5;
 }
 
 void PS_DisplayDepth(in float4 position : SV_Position, in float2 texcoord : TEXCOORD, out float3 color : SV_Target)
 {
-	float3 depth = GetLinearizedDepth(texcoord).xxx;
-	float3 normal = GetScreenSpaceNormal(texcoord);
+	float3 normal_vector = NormalVector(texcoord);
 
-	// Ordered dithering
-#if 1
-	const float dither_bit = 8.0; // Number of bits per channel. Should be 8 for most monitors.
-	// Calculate grid position
+	const float dither_bit = 8.0; //Number of bits per channel. Should be 8 for most monitors.
+
+	/*------------------------.
+	| :: Ordered Dithering :: |
+	'------------------------*/
+	//Calculate grid position
 	float grid_position = frac(dot(texcoord, (BUFFER_SCREEN_SIZE * float2(1.0 / 16.0, 10.0 / 36.0)) + 0.25));
-	// Calculate how big the shift should be
+
+	//Calculate how big the shift should be
 	float dither_shift = 0.25 * (1.0 / (pow(2, dither_bit) - 1.0));
-	// Shift the individual colors differently, thus making it even harder to see the dithering pattern
-	float3 dither_shift_RGB = float3(dither_shift, -dither_shift, dither_shift); // Subpixel dithering
-	// Modify shift acording to grid position.
-	dither_shift_RGB = lerp(2.0 * dither_shift_RGB, -2.0 * dither_shift_RGB, grid_position);
-	depth += dither_shift_RGB;
-#endif
 
-	color = depth;
-	if (iUIPresentType == 1)
-		color = normal;
-	if (iUIPresentType == 2)
-		color = lerp(normal, depth, step(BUFFER_WIDTH * 0.5, position.x));
+	//Shift the individual colors differently, thus making it even harder to see the dithering pattern
+	float3 dither_shift_RGB = float3(dither_shift, -dither_shift, dither_shift); //subpixel dithering
 
-	if (bUIShowOffset)
+	//modify shift acording to grid position.
+	dither_shift_RGB = lerp(2.0 * dither_shift_RGB, -2.0 * dither_shift_RGB, grid_position); //shift acording to grid position.
+
+	//shift the color by dither_shift
+	float3 depth_value = GetDepth(texcoord).rrr + dither_shift_RGB;
+
+	float3 normal_and_depth = lerp(normal_vector, depth_value, step(BUFFER_WIDTH * 0.5, position.x));
+
+	color = depth_value;
+
+	if(iUIPresentType == 1)
 	{
-		float3 color_orig = tex2D(ReShade::BackBuffer, texcoord).rgb;
+		color = normal_vector;
+	}
+	if(iUIPresentType == 2)
+	{
+		color = normal_and_depth;
+	}
 
-		// Blend depth and back buffer color with 'overlay' so the offset is more noticeable
-		color = lerp(2 * color * color_orig, 1.0 - 2.0 * (1.0 - color) * (1.0 - color_orig), max(color.r, max(color.g, color.b)) < 0.5 ? 0.0 : 1.0);
+	if(bUIShowOffset)
+	{
+		float3 backbuffer = tex2D(ReShade::BackBuffer, texcoord).rgb;
+
+		//Blend depth_value and backbuffer with 'overlay' so the offset is more noticeable
+		color = lerp(2*color*backbuffer, 1.0 - 2.0 * (1.0 - color) * (1.0 - backbuffer), max(color.r, max(color.g, color.b)) < 0.5 ? 0.0 : 1.0 );
+
+		return;
 	}
 }
 
 technique DisplayDepth <
-	ui_tooltip = "This shader helps finding the right preprocessor settings for depth input.\n\n"
-                 "By default calculated normals are shown and the goal is to make the displayed surface normals look smooth.\n"
-                 "Change the options for *_IS_REVERSED and *_IS_LOGARITHMIC in the variable editor until this happens.\n"
-                 "Change the 'Present type' to 'Depth map' and check whether close objects are dark and far away objects are white.\n\n"
-                 "When the right settings are found click on 'Edit global preprocessor definitions' and put the new values there."; >
+	ui_tooltip = "This shader helps finding the right\n"
+                 "preprocessor settings for the depth\n"
+                 "input.\n"
+                 "By default the calculated normals\n"
+                 "are shown and the goal is to make the\n"
+                 "displayed surface normals look smooth.\n"
+                 "Change the options for *_IS_REVERSED\n"
+                 "and *_IS_LOGARITHMIC in the variable editor\n"
+                 "until this happens.\n"
+                 "\n"
+                 "Change the 'Present type' to 'Depth map'\n"
+                 "and check whether close objects are dark\n"
+                 "and far away objects are white.\n"
+                 "\n"
+                 "When the right settings are found click\n"
+                 "'Edit global preprocessor definitions'\n"
+                 "(Variable editor in the 'Home' tab)\n"
+                 "and put them in there.\n"
+                 "\n"
+                 "Switching between normal map and\n"
+                 "depth map is possible via 'Present type'\n"
+                 "in the Options category.";
+>
 {
 	pass
 	{


### PR DESCRIPTION
As discussed, this change forces the user to interact with the preprocessor definitions, as users frequently miss the step of transferring the settings. I've used your cleaned version from the slim branch as template, as I presume you'd want this change to be applied to the master branch as well.