### PR TITLE
Updated Deband to 3.1

### DIFF
--- a/Shaders/Deband.fx
+++ b/Shaders/Deband.fx
@@ -30,74 +30,112 @@
  * 1.0  - Initial release
  * 1.1  - Replaced the algorithm with the one from MPV
  * 1.1a - Minor optimizations
- *        Removed unnecessary lines and replaced them with ReShadeFX intrinsic counterparts
+ *      - Removed unnecessary lines and replaced them with ReShadeFX intrinsic counterparts
  * 2.0  - Replaced "grain" with CeeJay.dk's ordered dithering algorithm and enabled it by default
- *        The configuration is now more simpler and straightforward
- *        Some minor code changes and optimizations
- *        Improved the algorithm and made it more robust by adding some of the madshi's
+ *      - The configuration is now more simpler and straightforward
+ *      - Some minor code changes and optimizations
+ *      - Improved the algorithm and made it more robust by adding some of the madshi's
  *        improvements to flash3kyuu_deband which should cause an increase in quality. Higher
  *        iterations/ranges should now yield higher quality debanding without too much decrease
  *        in quality.
- *        Changed licensing text and original source code URL
+ *      - Changed licensing text and original source code URL
+ * 3.0  - Replaced the entire banding detection algorithm with modified standard deviation and
+ *        Weber ratio analyses which give more accurate and error-free results compared to the
+ *        previous algorithm
+ *      - Added banding map debug view
+ *      - Added and redefined UI categories
+ *      - Added depth detection (credits to spiro) which should be useful when banding only
+ *        occurs in the sky texture for example
+ *      - Fixed a bug in random number generation which was causing artifacts on the upper left
+ *        side of the screen
+ *      - Dithering is now applied only when debanding a pixel as it should be which should
+ *        reduce the overall noise in the final texture
+ *      - Minor code optimizations
+ * 3.1  - Switched to chroma-based analysis from luma-based analysis which was causing artifacts
+ *        under some scenarios
+ *      - Changed parts of the code which was causing compatibility issues on some renderers
  */
 
 #include "ReShadeUI.fxh"
+#include "ReShade.fxh"
 
-uniform int threshold_preset < __UNIFORM_COMBO_INT1
-    ui_label = "Debanding strength";
-    ui_items = "Low\0Medium\0High\0Custom\0";
-    ui_tooltip = "Debanding presets. Use Custom to be able to use custom thresholds in the advanced section.";
-> = 0;
+uniform bool enable_weber <
+    ui_category = "Banding analysis";
+    ui_label = "Weber ratio";
+    ui_tooltip = "Weber ratio analysis that calculates the ratio of the each local pixel's intensity to average background intensity of all the local pixels.";
+    ui_type = "radio";
+> = true;
 
-uniform float range < __UNIFORM_SLIDER_FLOAT1
-    ui_min = 1.0;
-    ui_max = 32.0;
-    ui_step = 1.0;
-    ui_label = "Initial radius";
-    ui_tooltip = "The radius increases linearly for each iteration. A higher radius will find more gradients, but a lower radius will smooth more aggressively.";
-> = 24.0;
+uniform bool enable_sdeviation <
+    ui_category = "Banding analysis";
+    ui_label = "Standard deviation";
+    ui_tooltip = "Modified standard deviation analysis that calculates nearby pixels' intensity deviation from the current pixel instead of the mean.";
+    ui_type = "radio";
+> = true;
 
-uniform int iterations < __UNIFORM_SLIDER_INT1
-    ui_min = 1;
-    ui_max = 4;
-    ui_label = "Iterations";
-    ui_tooltip = "The number of debanding steps to perform per sample. Each step reduces a bit more banding, but takes time to compute.";
-> = 1;
-
-uniform float custom_avgdiff < __UNIFORM_SLIDER_FLOAT1
-    ui_min = 0.0;
-    ui_max = 255.0;
-    ui_step = 0.1;
-    ui_label = "Average threshold";
-    ui_tooltip = "Threshold for the difference between the average of reference pixel values and the original pixel value. Higher numbers increase the debanding strength but progressively diminish image details. In pixel shaders a 8-bit color step equals to 1.0/255.0";
-    ui_category = "Advanced";
-> = 1.8;
-
-uniform float custom_maxdiff < __UNIFORM_SLIDER_FLOAT1
-    ui_min = 0.0;
-    ui_max = 255.0;
-    ui_step = 0.1;
-    ui_label = "Maximum threshold";
-    ui_tooltip = "Threshold for the difference between the maximum difference of one of the reference pixel values and the original pixel value. Higher numbers increase the debanding strength but progressively diminish image details. In pixel shaders a 8-bit color step equals to 1.0/255.0";
-    ui_category = "Advanced";
-> = 4.0;
-
-uniform float custom_middiff < __UNIFORM_SLIDER_FLOAT1
-    ui_min = 0.0;
-    ui_max = 255.0;
-    ui_step = 0.1;
-    ui_label = "Middle threshold";
-    ui_tooltip = "Threshold for the difference between the average of diagonal reference pixel values and the original pixel value. Higher numbers increase the debanding strength but progressively diminish image details. In pixel shaders a 8-bit color step equals to 1.0/255.0";
-    ui_category = "Advanced";
-> = 2.0;
-
-uniform bool debug_output < __UNIFORM_RADIO_BOOL1
-    ui_label = "Debug view";
-    ui_tooltip = "Shows the low-pass filtered (blurred) output. Could be useful when making sure that range and iterations capture all of the banding in the picture.";
-    ui_category = "Advanced";
+uniform bool enable_depthbuffer <
+    ui_category = "Banding analysis";
+    ui_label = "Depth detection";
+    ui_tooltip = "Allows depth information to be used when analysing banding, pixels will only be analysed if they are in a certain depth. (e.g. debanding only the sky)";
+    ui_type = "radio";
 > = false;
 
-#include "ReShade.fxh"
+uniform float t1 <
+    ui_category = "Banding analysis";
+    ui_label = "Standard deviation threshold";
+    ui_max = 0.5;
+    ui_min = 0.0;
+    ui_step = 0.001;
+    ui_tooltip = "Standard deviations lower than this threshold will be flagged as flat regions with potential banding.";
+    ui_type = "slider";
+> = 0.007;
+
+uniform float t2 <
+    ui_category = "Banding analysis";
+    ui_label = "Weber ratio threshold";
+    ui_max = 2.0;
+    ui_min = 0.0;
+    ui_step = 0.01;
+    ui_tooltip = "Weber ratios lower than this threshold will be flagged as flat regions with potential banding.";
+    ui_type = "slider";
+> = 0.04;
+
+uniform float banding_depth <
+    ui_category = "Banding analysis";
+    ui_label = "Banding depth";
+    ui_max = 1.0;
+    ui_min = 0.0;
+    ui_step = 0.001;
+    ui_tooltip = "Pixels under this depth threshold will not be processed and returned as they are.";
+    ui_type = "slider";
+> = 1.0;
+
+uniform float range <
+    ui_category = "Banding detection & removal";
+    ui_label = "Radius";
+    ui_max = 32.0;
+    ui_min = 1.0;
+    ui_step = 1.0;
+    ui_tooltip = "The radius increases linearly for each iteration. A higher radius will find more gradients, but a lower radius will smooth more aggressively.";
+    ui_type = "slider";
+> = 24.0;
+
+uniform int iterations <
+    ui_category = "Banding detection & removal";
+    ui_label = "Iterations";
+    ui_max = 4;
+    ui_min = 1;
+    ui_tooltip = "The number of debanding steps to perform per sample. Each step reduces a bit more banding, but takes time to compute.";
+    ui_type = "slider";
+> = 1;
+
+uniform int debug_output <
+    ui_category = "Debug";
+    ui_items = "None\0Blurred (LPF) image\0Banding map\0";
+    ui_label = "Debug view";
+    ui_tooltip = "Blurred (LPF) image: Useful when tweaking radius and iterations to make sure all banding regions are blurred enough.\nBanding map: Useful when tweaking analysis parameters, continuous green regions indicate flat (i.e. banding) regions.";
+    ui_type = "combo";
+> = 0;
 
 // Reshade uses C rand for random, max cannot be larger than 2^15-1
 uniform int drandom < source = "random"; min = 0; max = 32767; >;
@@ -112,123 +150,77 @@ float permute(float x)
     return ((34.0 * x + 1.0) * x) % 289.0;
 }
 
-void analyze_pixels(float3 ori, sampler2D tex, float2 texcoord, float2 _range, float2 dir, out float3 ref_avg, out float3 ref_avg_diff, out float3 ref_max_diff, out float3 ref_mid_diff1, out float3 ref_mid_diff2)
-{
-    // Sample at quarter-turn intervals around the source pixel
-
-    // South-east
-    float3 ref = tex2Dlod(tex, float4(texcoord + _range * dir, 0.0, 0.0)).rgb;
-    float3 diff = abs(ori - ref);
-    ref_max_diff = diff;
-    ref_avg = ref;
-    ref_mid_diff1 = ref;
-
-    // North-west
-    ref = tex2Dlod(tex, float4(texcoord + _range * -dir, 0.0, 0.0)).rgb;
-    diff = abs(ori - ref);
-    ref_max_diff = max(ref_max_diff, diff);
-    ref_avg += ref;
-    ref_mid_diff1 = abs(((ref_mid_diff1 + ref) * 0.5) - ori);
-
-    // North-east
-    ref = tex2Dlod(tex, float4(texcoord + _range * float2(-dir.y, dir.x), 0.0, 0.0)).rgb;
-    diff = abs(ori - ref);
-    ref_max_diff = max(ref_max_diff, diff);
-    ref_avg += ref;
-    ref_mid_diff2 = ref;
-
-    // South-west
-    ref = tex2Dlod(tex, float4(texcoord + _range * float2( dir.y, -dir.x), 0.0, 0.0)).rgb;
-    diff = abs(ori - ref);
-    ref_max_diff = max(ref_max_diff, diff);
-    ref_avg += ref;
-    ref_mid_diff2 = abs(((ref_mid_diff2 + ref) * 0.5) - ori);
-
-    ref_avg *= 0.25; // Normalize avg
-    ref_avg_diff = abs(ori - ref_avg);
-}
-
 float3 PS_Deband(float4 vpos : SV_Position, float2 texcoord : TexCoord) : SV_Target
 {
-    // Settings
+    float3 ori = tex2Dlod(ReShade::BackBuffer, float4(texcoord, 0.0, 0.0)).rgb;
 
-    float avgdiff;
-    float maxdiff;
-    float middiff;
-
-    if (threshold_preset == 0) {
-        avgdiff = 0.6;
-        maxdiff = 1.9;
-        middiff = 1.2;
-    }
-    else if (threshold_preset == 1) {
-        avgdiff = 1.8;
-        maxdiff = 4.0;
-        middiff = 2.0;
-    }
-    else if (threshold_preset == 2) {
-        avgdiff = 3.4;
-        maxdiff = 6.8;
-        middiff = 3.3;
-    }
-    else if (threshold_preset == 3) {
-        avgdiff = custom_avgdiff;
-        maxdiff = custom_maxdiff;
-        middiff = custom_middiff;
-    }
-
-    // Normalize
-    avgdiff /= 255.0;
-    maxdiff /= 255.0;
-    middiff /= 255.0;
+    if (enable_depthbuffer && (ReShade::GetLinearizedDepth(texcoord) < banding_depth))
+        return ori;
 
     // Initialize the PRNG by hashing the position + a random uniform
-    float h = permute(permute(permute(texcoord.x) + texcoord.y) + drandom / 32767.0);
-
-    float3 ref_avg; // Average of 4 reference pixels
-    float3 ref_avg_diff; // The difference between the average of 4 reference pixels and the original pixel
-    float3 ref_max_diff; // The maximum difference between one of the 4 reference pixels and the original pixel
-    float3 ref_mid_diff1; // The difference between the average of SE and NW reference pixels and the original pixel
-    float3 ref_mid_diff2; // The difference between the average of NE and SW reference pixels and the original pixel
-
-    float3 ori = tex2Dlod(ReShade::BackBuffer, float4(texcoord, 0.0, 0.0)).rgb; // Original pixel
-    float3 res; // Final pixel
+    float3 m = float3(texcoord + 1.0, (drandom / 32767.0) + 1.0);
+    float h = permute(permute(permute(m.x) + m.y) + m.z);
 
     // Compute a random angle
     float dir  = rand(permute(h)) * 6.2831853;
-    float2 o = float2(cos(dir), sin(dir));
+    float2 o;
+    sincos(dir, o.y, o.x);
+    
+    // Distance calculations
+    float2 pt;
+    float dist;
 
     for (int i = 1; i <= iterations; ++i) {
-        // Compute a random distance
-        float dist = rand(h) * range * i;
-        float2 pt = dist * BUFFER_PIXEL_SIZE;
-
-        analyze_pixels(ori, ReShade::BackBuffer, texcoord, pt, o,
-                       ref_avg,
-                       ref_avg_diff,
-                       ref_max_diff,
-                       ref_mid_diff1,
-                       ref_mid_diff2);
-
-        float3 ref_avg_diff_threshold = avgdiff * i;
-        float3 ref_max_diff_threshold = maxdiff * i;
-        float3 ref_mid_diff_threshold = middiff * i;
-
-        // Fuzzy logic based pixel selection
-        float3 factor = pow(saturate(3.0 * (1.0 - ref_avg_diff  / ref_avg_diff_threshold)) *
-                            saturate(3.0 * (1.0 - ref_max_diff  / ref_max_diff_threshold)) *
-                            saturate(3.0 * (1.0 - ref_mid_diff1 / ref_mid_diff_threshold)) *
-                            saturate(3.0 * (1.0 - ref_mid_diff2 / ref_mid_diff_threshold)), 0.1);
-
-        if (debug_output)
-            res = ref_avg;
-        else
-            res = lerp(ori, ref_avg, factor);
-
+        dist = rand(h) * range * i;
+        pt = dist * BUFFER_PIXEL_SIZE;
+    
         h = permute(h);
     }
+    
+    // Sample at quarter-turn intervals around the source pixel
+    float3 ref[4] = {
+        tex2Dlod(ReShade::BackBuffer, float4(mad(pt,                  o, texcoord), 0.0, 0.0)).rgb, // SE
+        tex2Dlod(ReShade::BackBuffer, float4(mad(pt,                 -o, texcoord), 0.0, 0.0)).rgb, // NW
+        tex2Dlod(ReShade::BackBuffer, float4(mad(pt, float2(-o.y,  o.x), texcoord), 0.0, 0.0)).rgb, // NE
+        tex2Dlod(ReShade::BackBuffer, float4(mad(pt, float2( o.y, -o.x), texcoord), 0.0, 0.0)).rgb  // SW
+    };
 
-	const float dither_bit = 8.0; //Number of bits per channel. Should be 8 for most monitors.
+    // Calculate weber ratio
+    float3 mean = (ori + ref[0] + ref[1] + ref[2] + ref[3]) * 0.2;
+    float3 k = abs(ori - mean);
+    for (int j = 0; j < 4; ++j) {
+        k += abs(ref[j] - mean);
+    }
+
+    k = k * 0.2 / mean;
+
+    // Calculate std. deviation
+    float3 sd = 0.0;
+
+    for (int j = 0; j < 4; ++j) {
+        sd += pow(ref[j] - ori, 2);
+    }
+
+    sd = sqrt(sd * 0.25);
+
+    // Generate final output
+    float3 output;
+
+    if (debug_output == 2)
+        output = float3(0.0, 1.0, 0.0);
+    else
+        output = (ref[0] + ref[1] + ref[2] + ref[3]) * 0.25;
+
+    // Generate a binary banding map
+    bool3 banding_map = true;
+
+    if (debug_output != 1) {
+        if (enable_weber)
+            banding_map = banding_map && k <= t2 * iterations;
+
+        if (enable_sdeviation)
+            banding_map = banding_map && sd <= t1 * iterations;
+    }
 
 	/*------------------------.
 	| :: Ordered Dithering :: |
@@ -237,18 +229,15 @@ float3 PS_Deband(float4 vpos : SV_Position, float2 texcoord : TexCoord) : SV_Tar
 	float grid_position = frac(dot(texcoord, (BUFFER_SCREEN_SIZE * float2(1.0 / 16.0, 10.0 / 36.0)) + 0.25));
 
 	//Calculate how big the shift should be
-	float dither_shift = 0.25 * (1.0 / (pow(2, dither_bit) - 1.0));
+	float dither_shift = 0.25 * (1.0 / (pow(2, BUFFER_COLOR_BIT_DEPTH) - 1.0));
 
 	//Shift the individual colors differently, thus making it even harder to see the dithering pattern
 	float3 dither_shift_RGB = float3(dither_shift, -dither_shift, dither_shift); //subpixel dithering
 
 	//modify shift acording to grid position.
 	dither_shift_RGB = lerp(2.0 * dither_shift_RGB, -2.0 * dither_shift_RGB, grid_position); //shift acording to grid position.
-
-	//shift the color by dither_shift
-	res += dither_shift_RGB;
-
-    return res;
+    
+    return banding_map ? output + dither_shift_RGB : ori;
 }
 
 technique Deband <


### PR DESCRIPTION
**3.0:**
- Replaced the entire banding detection algorithm with modified standard deviation and Weber ratio analyses which give more accurate and error-free results compared to the previous algorithm
- Added banding map debug view
- Added and redefined UI categories
- Added depth detection (credits to spiro) which should be useful when banding only occurs in the sky texture for example
- Fixed a bug in random number generation which was causing artifacts on the upper left side of the screen
- Dithering is now applied only when debanding a pixel as it should be which should reduce the overall noise in the final texture
- Minor code optimizations

**3.1:**
- Switched to chroma-based analysis from luma-based analysis which was causing artifacts under some scenarios
- Changed parts of the code which was causing compatibility issues on some renderers