### PR TITLE
added effect entry 18 for crt-royale-reshade

### DIFF
--- a/EffectPackages.ini
+++ b/EffectPackages.ini
@@ -166,6 +166,15 @@ DownloadUrl=https://github.com/retroluxfilm/reshade-vrtoolkit/archive/refs/heads
 RepositoryUrl=https://github.com/retroluxfilm/reshade-vrtoolkit
 EffectFiles=VRToolkit.fx
 
+[18]
+PackageName=CRT-Royale-ReShade by akgunter
+PackageDescription=A port of CRT-Royale from Libretro to ReShade
+InstallPath=.\reshade-shaders\Shaders\akgunter
+TextureInstallPath=.\reshade-shaders\Textures
+DownloadUrl=https://github.com/akgunter/crt-royale-reshade/archive/refs/heads/master.zip
+RepositoryUrl=https://github.com/akgunter/crt-royale-reshade
+EffectFiles=crt-royale.fx
+
 [20]
 PackageName=Legacy effects
 PackageDescription=Effects known from previous ReShade versions (AmbientLight, ...)


### PR DESCRIPTION
This adds an entry for CRT-Royale-ReShade to the installer's list of shaders. Since mine is the newest addition to the list, I've placed it at the end, but prior to the legacy shaders. Currently that corresponds to slot 18 with the legacy shaders still at slot 20.

I checked for typos, but I've not tested it for correctness. I can do that if need be.