### PR TITLE
Add PPFX_SSDO limiter

### DIFF
--- a/Shaders/PPFX_SSDO.fx
+++ b/Shaders/PPFX_SSDO.fx
@@ -114,12 +114,12 @@ uniform int pSSDOBounceLOD <
 
 uniform float pSSDOFilterRadius <
     ui_label = "Filter Radius";
-    ui_tooltip = "The blur radius that is used to filter out the noise the technique produces. Don't push this too high, everything between 8 - 24 is recommended (depending from SampleAmount, SampleRange, Intensity and Amount).";
+    ui_tooltip = "The blur radius that is used to filter out the noise the technique produces. Don't push this too high, everything between 8 - 24 is recommended (depending from Sample Count, Sample Range, Intensity and Amount).";
     ui_type = "slider";
     ui_min = 2.0;
     ui_max = 100.0;
     ui_step = 1.0;
-> = 8.0;
+> = 20.0;
 
 uniform float pSSDOAngleThreshold <
     ui_label = "SSDO Angle Threshold";

--- a/Shaders/PPFX_SSDO.fx
+++ b/Shaders/PPFX_SSDO.fx
@@ -119,7 +119,7 @@ uniform float pSSDOFilterRadius <
     ui_min = 2.0;
     ui_max = 100.0;
     ui_step = 1.0;
-> = 16.0;
+> = 8.0;
 
 uniform float pSSDOAngleThreshold <
     ui_label = "SSDO Angle Threshold";

--- a/Shaders/PPFX_SSDO.fx
+++ b/Shaders/PPFX_SSDO.fx
@@ -54,9 +54,9 @@ uniform float pSSDOMax <
     ui_tooltip = "A limiter to the maximum SSDO effect. Can help to prevent artifacts in very dark areas.";
     ui_type = "slider";
     ui_min = 0.01;
-    ui_max = 10.0;
+    ui_max = 1.0;
     ui_step = 0.01;
-> = 10;
+> = 1.0;
 
 uniform float pSSDOBounceMultiplier <
     ui_label = "SSDO Indirect Bounce Color Multiplier";

--- a/Shaders/PPFX_SSDO.fx
+++ b/Shaders/PPFX_SSDO.fx
@@ -49,6 +49,15 @@ uniform float pSSDOAmount <
     ui_step = 0.01;
 > = 1.5;
 
+uniform float pSSDOMax <
+    ui_label = "SSDO Max";
+    ui_tooltip = "A limiter to the maximum SSDO effect. Can help to prevent artifacts in very dark areas.";
+    ui_type = "slider";
+    ui_min = 0.01;
+    ui_max = 10.0;
+    ui_step = 0.01;
+> = 10;
+
 uniform float pSSDOBounceMultiplier <
     ui_label = "SSDO Indirect Bounce Color Multiplier";
     ui_tooltip = "SSDO includes an indirect bounce of light which means that colors of objects may interact with each other. This value controls the effects' visibility.";
@@ -317,7 +326,7 @@ float4 viewSpace(float2 txCoords)
 			float distFade = max(0.0,SSDO_CONTRIB_RANGE-length(dirVec))/SSDO_CONTRIB_RANGE; // attenuation
 			ssdo += albedoFetch * visibility * distFade * distFade * pSSDOAmount;
 		}
-		ssdo /= pSSDOSampleAmount;
+		ssdo = min(pSSDOMax,ssdo/pSSDOSampleAmount);
 		
 		return float4(saturate(1.0-ssdo*smoothstep(pSSDOFadeEnd,pSSDOFadeStart,vsOrig.w)),vsOrig.w);
 	}

--- a/Shaders/PPFX_SSDO.fx
+++ b/Shaders/PPFX_SSDO.fx
@@ -50,7 +50,7 @@ uniform float pSSDOAmount <
 > = 1.5;
 
 uniform float pSSDOMax <
-    ui_label = "SSDO Max";
+    ui_label = "Max SSDO";
     ui_tooltip = "A limiter to the maximum SSDO effect. Can help to prevent artifacts in very dark areas.";
     ui_type = "slider";
     ui_min = 0.01;
@@ -114,12 +114,12 @@ uniform int pSSDOBounceLOD <
 
 uniform float pSSDOFilterRadius <
     ui_label = "Filter Radius";
-    ui_tooltip = "The blur radius that is used to filter out the noise the technique produces. Don't push this too high, everything between 8 - 24 is recommended (depending from Sample Count, Sample Range, Intensity and Amount).";
+    ui_tooltip = "The blur radius that is used to filter out the noise the technique produces. Don't push this too high, everything between 8 - 24 is recommended (depending from Sample Count, Sample Range, Intensity, Amount and Max SSDO).";
     ui_type = "slider";
     ui_min = 2.0;
     ui_max = 100.0;
     ui_step = 1.0;
-> = 20.0;
+> = 16.0;
 
 uniform float pSSDOAngleThreshold <
     ui_label = "SSDO Angle Threshold";


### PR DESCRIPTION
When using PPFX_SSDO, the shader effect will overflow in certain really dark areas. The pSSDOMAX parameter fixes this issue by limiting the maximum effect of this shader. It is set as 1 by default, so updating this shader will bring no issues for previous users. For testing purposes, I set it to 0.33 in a certain game, and it worked wonderfully.

In addition to that, I also updated the pSSDOFilterRadius tooltip to include the new parameter, and updated some names to match the labels.