### PR TITLE
Update URLs of add-ons by seri14 to static address

### DIFF
--- a/Addons.ini
+++ b/Addons.ini
@@ -111,26 +111,26 @@ RepositoryUrl=https://github.com/Flugan/Geo3D-Installer
 PackageName=Editor History by seri14
 PackageDescription=Adds a history window that keeps track of technique and variable modifications, with the ability to go back to a previous state in the history.
 RepositoryUrl=https://github.com/cot6/reshade-addons
-DownloadUrl32=https://github.com/cot6/reshade-addons/releases/download/v10.5.1/ReShade32-EditorHistory-By-seri14.zip
-DownloadUrl64=https://github.com/cot6/reshade-addons/releases/download/v10.5.1/ReShade64-EditorHistory-By-seri14.zip
+DownloadUrl32=https://github.com/cot6/reshade-addons/releases/download/setup-release-reference/ReShade32-EditorHistory-By-seri14.zip
+DownloadUrl64=https://github.com/cot6/reshade-addons/releases/download/setup-release-reference/ReShade64-EditorHistory-By-seri14.zip
 
 [18]
 PackageName=Screenshot by seri14
 PackageDescription=Extended screenshot functionality, like being able to shoot continuous screenshots, additional image file formats etc.
 RepositoryUrl=https://github.com/cot6/reshade-addons
-DownloadUrl32=https://github.com/cot6/reshade-addons/releases/download/v10.5.1/ReShade32-Screenshot-By-seri14.zip
-DownloadUrl64=https://github.com/cot6/reshade-addons/releases/download/v10.5.1/ReShade64-Screenshot-By-seri14.zip
+DownloadUrl32=https://github.com/cot6/reshade-addons/releases/download/setup-release-reference/ReShade32-Screenshot-By-seri14.zip
+DownloadUrl64=https://github.com/cot6/reshade-addons/releases/download/setup-release-reference/ReShade64-Screenshot-By-seri14.zip
 
 [19]
 PackageName=UIBind by seri14
 PackageDescription=Adds support for "ui_bind" annotations on uniform variables to have them automatically change preprocessor definitions.
 RepositoryUrl=https://github.com/cot6/reshade-addons
-DownloadUrl32=https://github.com/cot6/reshade-addons/releases/download/v10.5.1/ReShade32-UIBind-By-seri14.zip
-DownloadUrl64=https://github.com/cot6/reshade-addons/releases/download/v10.5.1/ReShade64-UIBind-By-seri14.zip
+DownloadUrl32=https://github.com/cot6/reshade-addons/releases/download/setup-release-reference/ReShade32-UIBind-By-seri14.zip
+DownloadUrl64=https://github.com/cot6/reshade-addons/releases/download/setup-release-reference/ReShade64-UIBind-By-seri14.zip
 
 [20]
 PackageName=Adjust Depth by seri14
 PackageDescription=Adds a button to DisplayDepth.fx which takes the configured variables and sets the related preprocessor definitions.
 RepositoryUrl=https://github.com/cot6/reshade-addons
-DownloadUrl32=https://github.com/cot6/reshade-addons/releases/download/v10.5.1/ReShade32-AdjustDepth-By-seri14.zip
-DownloadUrl64=https://github.com/cot6/reshade-addons/releases/download/v10.5.1/ReShade64-AdjustDepth-By-seri14.zip
+DownloadUrl32=https://github.com/cot6/reshade-addons/releases/download/setup-release-reference/ReShade32-AdjustDepth-By-seri14.zip
+DownloadUrl64=https://github.com/cot6/reshade-addons/releases/download/setup-release-reference/ReShade64-AdjustDepth-By-seri14.zip


### PR DESCRIPTION
Release Page: https://github.com/cot6/reshade-addons/releases/tag/setup-release-reference