### PR TITLE
Replace MajorPainTheCactus AutoHDR Addons with more up to date EndlesslyFlowering version

### DIFF
--- a/Addons.ini
+++ b/Addons.ini
@@ -80,11 +80,11 @@ DownloadUrl64=https://github.com/FransBouma/IgcsConnector/releases/download/v251
 RepositoryUrl=https://github.com/FransBouma/IgcsConnector
 
 [12]
-PackageName=AutoHDR by MajorPainTheCactus
-PackageDescription=AutoHDR add-on (requires https://github.com/MajorPainTheCactus/AutoHDR-ReShade/blob/main/AutoHDR.fx)
-RepositoryUrl=https://github.com/MajorPainTheCactus/AutoHDR-ReShade
-# DownloadUrl32=https://github.com/MajorPainTheCactus/AutoHDR-ReShade/raw/main/AutoHDR32.addon
-# DownloadUrl64=https://github.com/MajorPainTheCactus/AutoHDR-ReShade/raw/main/AutoHDR64.addon
+PackageName=AutoHDR by EndlesslyFlowering
+PackageDescription=AutoHDR add-on (requires https://github.com/EndlesslyFlowering/ReShade_HDR_shaders/blob/master/Shaders/lilium__inverse_tone_mapping.fx or https://github.com/Filoppi/PumboAutoHDR/blob/master/Shaders/Pumbo/AdvancedAutoHDR.fx to fix gamma and actually re-tonemap to HDR). Original version by MajorPainTheCactus.
+RepositoryUrl=https://github.com/EndlesslyFlowering/AutoHDR-ReShade
+# DownloadUrl32=https://github.com/EndlesslyFlowering/AutoHDR-ReShade/raw/main/AutoHDR32.addon
+# DownloadUrl64=https://github.com/EndlesslyFlowering/AutoHDR-ReShade/raw/main/AutoHDR64.addon
 
 [13]
 PackageName=LiveSplit Overlay by mleise


### PR DESCRIPTION
EndlesslyFlowering (Lilium) AutoHDR fork has improved on the original in many ways, increasing compatibility and making it simpler to use.
One of the most important changes is that it uses scRGB HDR (sRGB/BT.709) by default, as opposed to HDR10 (BT.2020), thus making the inverse tonemapping only require a gamma fix to work, instead of having to also convert the color space.

Massive thanks and credit to @MajorPainTheCactus for the original.