### PR TITLE
Added Game Bridge to the installer list

### DIFF
--- a/Addons.ini
+++ b/Addons.ini
@@ -151,6 +151,6 @@ RepositoryUrl=https://github.com/clshortfuse/renodx
 [22]
 PackageName=3DGameBridge by Janthony & DinnerBram
 PackageDescription=Enable stereoscopic 3D on LeiaSR displays for SBS content
-DownloadUrl32=https://github.com/JoeyAnthony/3DGameBridgeProjects/releases/latest/srReshade.zip
-DownloadUrl64=https://github.com/JoeyAnthony/3DGameBridgeProjects/releases/latest/srReshade.zip
+DownloadUrl32=https://github.com/JoeyAnthony/3DGameBridgeProjects/releases/latest/download/srReshade.zip
+DownloadUrl64=https://github.com/JoeyAnthony/3DGameBridgeProjects/releases/latest/download/srReshade.zip
 RepositoryUrl=https://github.com/JoeyAnthony/3DGameBridgeProjects

--- a/Addons.ini
+++ b/Addons.ini
@@ -147,3 +147,10 @@ DownloadUrl64=https://github.com/cot6/reshade-addons/releases/download/setup-rel
 PackageName=RenoDX by ShortFuse
 PackageDescription=A toolset to mod games, short for "Renovation Engine for DirectX Games". Currently it can replace shaders, inject buffers, add overlays, upgrade swapchains, upgrade texture resources ...
 RepositoryUrl=https://github.com/clshortfuse/renodx
+
+[22]
+PackageName=3DGameBridge by Janthony & DinnerBram
+PackageDescription=Enable stereoscopic 3D on LeiaSR displays for SBS content
+DownloadUrl32=https://github.com/JoeyAnthony/3DGameBridgeProjects/releases/latest/srReshade.zip
+DownloadUrl64=https://github.com/JoeyAnthony/3DGameBridgeProjects/releases/latest/srReshade.zip
+RepositoryUrl=https://github.com/JoeyAnthony/3DGameBridgeProjects


### PR DESCRIPTION
Added new URL for the .zip file containing both the .addon32 and .addon64.

The plan is to always upload a file called "srReshade.zip" when we make a new release. If I understand the installer mechanism correctly, it should look for a file with extension ".addon32" and ".addon64" when DownloadUrl32 and DownloadUrl64 are specified respectively. Both of these files are present in `srReshade.zip`, see attachment.

**Note:** The new release with the `srReshade.zip` is not yet live, it will go live on 13-09-2024 (next week friday).

[srReshade.zip](https://github.com/user-attachments/files/16898845/srReshade.zip)
