### PR TITLE
Update The Sims 4 executable names and rendering API's

### DIFF
--- a/Compatibility.ini
+++ b/Compatibility.ini
@@ -886,8 +886,11 @@ DepthReversed=0
 [TS4.exe]
 RenderApi=D3D9
 DepthReversed=0
-[TS4_x64.exe]
+[TS4_DX9_x64.exe]
 RenderApi=D3D9
+DepthReversed=0
+[TS4_x64.exe]
+RenderApi=D3D11
 DepthReversed=0
 
 # The Stanley Parable: Ultra Deluxe


### PR DESCRIPTION
An update for The Sims 4 due to the game switching to a DX11 rendering API with new executable names as well as a new DX9 fallback executable name.