### PR TITLE
ARK and Battlebit banned

### DIFF
--- a/Compatibility.ini
+++ b/Compatibility.ini
@@ -30,6 +30,12 @@ RenderApi=D3D11
 Banned=1
 RenderApi=D3D12
 
+# ARK: Survival Evolved
+[ShooterGame.exe]
+Banned=1
+[ShooterGame_BE.exe]
+Banned=1
+
 # Assassin's Creed IV: Black Flag
 [ACB4SP.exe]
 RenderApi=D3D11
@@ -87,6 +93,7 @@ RenderApi=D3D11
 # Battlebit Remastered
 [BattleBit.exe]
 RenderApi=D3D11
+Banned=1
 
 # Battlefield 3
 [bf3.exe]


### PR DESCRIPTION
ARK banned due to Battleeye not allowing it, but people are also saying even the no BE client also doesn't allow it.

Battlebit bans Reshade acording to a forum reply by a Battlebit employee .. due to EAC. But maybe we should doublecheck with EAC if this has changed since.