### PR TITLE
Update effect list of Barbatos Bachiko repository (March)

### DIFF
--- a/EffectPackages.ini
+++ b/EffectPackages.ini
@@ -348,7 +348,7 @@ InstallPath=.\reshade-shaders\Shaders\Barbatos
 TextureInstallPath=.\reshade-shaders\Textures\Barbatos
 DownloadUrl=https://github.com/BarbatosBachiko/Reshade-Shaders/archive/refs/heads/main.zip
 RepositoryUrl=https://github.com/BarbatosBachiko/Reshade-Shaders
-EffectFiles=CAA.fx,ColorGrading.fx,DFTAA.fx,DLAA_Lite.fx,GBloom.fx,MaterialFX.fx,NeoGI.fx,NeoSSAO.fx,Outline.fx,RCAS.fx,SSAO.fx,SSRT.fx,Shading.fx,ShadingDX9.fx,uEmboss.fx,uFakeHDR.fx
+EffectFiles=ColorGrading.fx,DAA.fx,GBloom.fx,MaterialFX.fx,NeoGI.fx,NeoSSAO.fx,Outline.fx,RCAS.fx,SSAO.fx,SSRT.fx,Shading.fx,uEmboss.fx,uFakeHDR.fx
 
 [38]
 PackageName=smolbbsoopshaders by smolbbsoop


### PR DESCRIPTION
Removed ShadingDX9.fx (Outdated, replaced by Shading.fx) Removed DFTAA (Outdated moved to Wip Repository)
Removed DLAA_Lite (Replaced by DAA.fx)
Removed CAA.fx (Replaced by DAA.fx)
Added DAA.fx