### PR TITLE
Ban - Sea Of Thieves

### DIFF
--- a/Compatibility.ini
+++ b/Compatibility.ini
@@ -848,6 +848,12 @@ Banned=1
 [SCUM_Launcher.exe]
 Banned=1
 
+# Sea of Thieves 
+[SoTGame.exe]
+Banned=1
+[SeaOfThieves.exe]
+Banned=1
+
 # Sekiro: Shadows Die Twice
 [sekiro.exe]
 RenderApi=D3D11


### PR DESCRIPTION
The official Sea of Thieves support site say "The use of Third-Party Tools to modify the visual experience of Sea of Thieves such as ReShade filters is considered a bannable offence."

https://support.seaofthieves.com/articles/24643308439314-Support-Enforcement-Policy-Updates