### PR TITLE
Update effect list of Barbatos Bachiko repository (November)

### DIFF
--- a/EffectPackages.ini
+++ b/EffectPackages.ini
@@ -340,7 +340,7 @@ InstallPath=.\reshade-shaders\Shaders\Barbatos
 TextureInstallPath=.\reshade-shaders\Textures\Barbatos
 DownloadUrl=https://github.com/BarbatosBachiko/Reshade-Shaders/archive/refs/heads/main.zip
 RepositoryUrl=https://github.com/BarbatosBachiko/Reshade-Shaders
-EffectFiles=BarbatosNVSharpen.fx,Barbatos_SSR.fx,ColorGrading.fx,DAA.fx,EVI.fx,GBloom.fx,LumaFog.fx,MaterialFX.fx,NeoGI.fx,NeoSSAO.fx,Outline.fx,RCAS.fx,SSRT.fx,Shading.fx,uFakeHDR.fx,VividTone.fx,XeGTAO.fx,uEmboss.fx
+EffectFiles=BarbatosNVSharpen.fx,Barbatos_SSR.fx,Barbatos_SSR_Lite.fx,DAA.fx,MiAO.fx,NeoSSAO.fx,S_Outline.fx,SoftMotion.fx,VividTone.fx,XeGTAO.fx,uFakeHDR.fx
 
 [37]
 PackageName=smolbbsoopshaders by smolbbsoop


### PR DESCRIPTION
Add
SoftMotion.fx
S_Outline.fx
MiAO.fx
Barbatos_SSR_Lite.fx

Removed 
ColorGrading.fx
EVI.fx
GBloom.fx
LumaFog.fx
MaterialFX.fx
Outline.fx
SSRT.fx
Shading.fx
uEmboss.fx
Moved to: https://github.com/BarbatosBachiko/BBFX_OLD-Shaders/tree/main