### PR TITLE
Ban DayZ

### DIFF
--- a/Compatibility.ini
+++ b/Compatibility.ini
@@ -271,6 +271,10 @@ DepthReversed=0
 RenderApi=D3D11
 DepthReversed=1
 
+# DayZ
+[DayZ_x64.exe]
+Banned=1
+
 # Deadlock
 [deadlock.exe]
 Banned=1


### PR DESCRIPTION
Ban due to developer blocking in the new 1.29 patch that releases tomorrow on the 27th.

https://x.com/DayZ/status/1988925535913689421

We don't need to effectuate this change until the patch releases, so it can wait until tomorrow.