### PR TITLE
Add Display Commander add-on to Addons.ini

### DIFF
--- a/Addons.ini
+++ b/Addons.ini
@@ -160,8 +160,8 @@ DownloadUrl64=https://github.com/JoeyAnthony/3DGameBridgeProjects/releases/lates
 PackageName=AutoReload by seri14
 PackageDescription=Automatically reloads effect files when modified on disk
 RepositoryUrl=https://github.com/cot6/reshade-addons
-DownloadUrl32=https://github.com/cot6/reshade-addons/releases/download/setup-release-reference/ReShade32-AutoReload-By-seri14.zip 
-DownloadUrl64=https://github.com/cot6/reshade-addons/releases/download/setup-release-reference/ReShade64-AutoReload-By-seri14.zip 
+DownloadUrl32=https://github.com/cot6/reshade-addons/releases/download/setup-release-reference/ReShade32-AutoReload-By-seri14.zip
+DownloadUrl64=https://github.com/cot6/reshade-addons/releases/download/setup-release-reference/ReShade64-AutoReload-By-seri14.zip
 
 [24]
 PackageName=Screenshot to clipboard by crosire
@@ -176,3 +176,10 @@ PackageDescription=Xinp Gamepad is an Xinput add-on for ReShade that lets shader
 EffectInstallPath=.\reshade-shaders\Shaders\Xinp
 DownloadUrl=https://github.com/BlueSkyDefender/Xinp/releases/latest/download/Xinp_Release.zip
 RepositoryUrl=https://github.com/BlueSkyDefender/Xinp
+
+[26]
+PackageName=Display Commander by pmnoxx
+PackageDescription=Display Commander is advanced fps limiter, window control, OSD, and more.
+DownloadUrl32=https://github.com/pmnoxx/display-commander/releases/latest/download/zzz_display_commander.addon32
+DownloadUrl64=https://github.com/pmnoxx/display-commander/releases/latest/download/zzz_display_commander.addon64
+RepositoryUrl=https://github.com/pmnoxx/display-commander


### PR DESCRIPTION
Adds **[Display Commander](https://github.com/pmnoxx/display-commander)** to `Addons.ini`:

- Description / PackageName
- DownloadUrl32/DownloadUrl64 to .addon32/.addon64
- RepositoryUrl
